### PR TITLE
feat: add create board dialog with validation and server action

### DIFF
--- a/app/_components/create-board-dialog.tsx
+++ b/app/_components/create-board-dialog.tsx
@@ -1,0 +1,224 @@
+'use client'
+
+import { Plus } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { useId, useState, useTransition } from 'react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { createBoard } from '@/lib/board/actions'
+import { createBoardSchema } from '@/lib/board/schemas'
+import { BOARD_COLORS } from '@/lib/board/types'
+import { cn } from '@/lib/utils'
+
+type TFormErrors = {
+  title?: string
+  description?: string
+  backgroundColor?: string
+}
+
+export function CreateBoardDialog() {
+  const router = useRouter()
+  const titleId = useId()
+  const descriptionId = useId()
+  const [open, setOpen] = useState(false)
+  const [isPending, startTransition] = useTransition()
+
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('')
+  const [backgroundColor, setBackgroundColor] = useState('#0079bf')
+  const [errors, setErrors] = useState<TFormErrors>({})
+
+  function resetForm() {
+    setTitle('')
+    setDescription('')
+    setBackgroundColor('#0079bf')
+    setErrors({})
+  }
+
+  function handleOpenChange(isOpen: boolean) {
+    setOpen(isOpen)
+    if (!isOpen) {
+      resetForm()
+    }
+  }
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+
+    // Validar en cliente primero
+    const validated = createBoardSchema.safeParse({
+      title,
+      description: description || null,
+      backgroundColor,
+    })
+
+    if (!validated.success) {
+      const fieldErrors: TFormErrors = {}
+      for (const issue of validated.error.issues) {
+        const field = issue.path[0] as keyof TFormErrors
+        fieldErrors[field] = issue.message
+      }
+      setErrors(fieldErrors)
+      return
+    }
+
+    setErrors({})
+
+    startTransition(async () => {
+      const result = await createBoard({
+        title: validated.data.title,
+        description: validated.data.description,
+        backgroundColor: validated.data.backgroundColor,
+      })
+
+      if (result.success && result.data) {
+        toast.success('Tablero creado correctamente')
+        setOpen(false)
+        resetForm()
+        router.push(`/board/${result.data.id}`)
+      } else {
+        toast.error(result.error ?? 'Error al crear el tablero')
+      }
+    })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button size='sm' className='gap-2'>
+          <Plus className='h-4 w-4' />
+          Crear tablero
+        </Button>
+      </DialogTrigger>
+      <DialogContent className='sm:max-w-md'>
+        <DialogHeader>
+          <DialogTitle>Crear nuevo tablero</DialogTitle>
+          <DialogDescription>
+            Crea un tablero para organizar tus tareas y proyectos.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit}>
+          <div className='space-y-4 py-4'>
+            {/* Vista previa del tablero */}
+            <div
+              className='h-24 rounded-lg flex items-center justify-center transition-colors'
+              style={{ backgroundColor }}
+            >
+              <span className='text-white font-semibold text-lg drop-shadow-md'>
+                {title || 'Mi tablero'}
+              </span>
+            </div>
+
+            {/* Título */}
+            <div className='space-y-2'>
+              <Label htmlFor={titleId}>
+                Título <span className='text-destructive'>*</span>
+              </Label>
+              <Input
+                id={titleId}
+                placeholder='Nombre del tablero'
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                disabled={isPending}
+                className={cn(errors.title && 'border-destructive')}
+              />
+              {errors.title && (
+                <p className='text-sm text-destructive'>{errors.title}</p>
+              )}
+            </div>
+
+            {/* Descripción */}
+            <div className='space-y-2'>
+              <Label htmlFor={descriptionId}>Descripción (opcional)</Label>
+              <Input
+                id={descriptionId}
+                placeholder='Describe el propósito del tablero'
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                disabled={isPending}
+                className={cn(errors.description && 'border-destructive')}
+              />
+              {errors.description && (
+                <p className='text-sm text-destructive'>{errors.description}</p>
+              )}
+            </div>
+
+            {/* Selector de color */}
+            <div className='space-y-2'>
+              <Label>Color de fondo</Label>
+              <div className='flex flex-wrap gap-2'>
+                {BOARD_COLORS.map((color) => (
+                  <button
+                    key={color.value}
+                    type='button'
+                    title={color.name}
+                    className={cn(
+                      'h-8 w-8 rounded-md transition-all hover:scale-110',
+                      backgroundColor === color.value &&
+                        'ring-2 ring-offset-2 ring-primary',
+                    )}
+                    style={{ backgroundColor: color.value }}
+                    onClick={() => setBackgroundColor(color.value)}
+                    disabled={isPending}
+                  />
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button
+              type='button'
+              variant='outline'
+              onClick={() => setOpen(false)}
+              disabled={isPending}
+            >
+              Cancelar
+            </Button>
+            <Button type='submit' disabled={isPending}>
+              {isPending ? (
+                <span className='flex items-center gap-2'>
+                  <svg
+                    className='animate-spin h-4 w-4'
+                    fill='none'
+                    viewBox='0 0 24 24'
+                    aria-hidden='true'
+                  >
+                    <title>Cargando</title>
+                    <circle
+                      className='opacity-25'
+                      cx='12'
+                      cy='12'
+                      r='10'
+                      stroke='currentColor'
+                      strokeWidth='4'
+                    />
+                    <path
+                      className='opacity-75'
+                      fill='currentColor'
+                      d='M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z'
+                    />
+                  </svg>
+                  Creando...
+                </span>
+              ) : (
+                'Crear tablero'
+              )}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import { Suspense } from 'react'
+import { CreateBoardDialog } from '@/app/_components/create-board-dialog'
 import { AnimatedNavbar } from '@/components/animations/animated-navbar'
 import { ThemeSwitcher } from '@/components/kibo-ui/theme-switcher'
 import { getCurrentUser } from '@/lib/auth/get-user'
@@ -13,7 +14,12 @@ async function UserSection() {
     return null
   }
 
-  return <UserNav user={user} />
+  return (
+    <>
+      <CreateBoardDialog />
+      <UserNav user={user} />
+    </>
+  )
 }
 
 function UserSkeleton() {

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,143 @@
+'use client'
+
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { XIcon } from 'lucide-react'
+import type * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot='dialog' {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot='dialog-trigger' {...props} />
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot='dialog-portal' {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot='dialog-close' {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot='dialog-overlay'
+      className={cn(
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal data-slot='dialog-portal'>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot='dialog-content'
+        className={cn(
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot='dialog-close'
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className='sr-only'>Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot='dialog-header'
+      className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot='dialog-footer'
+      className={cn(
+        'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot='dialog-title'
+      className={cn('text-lg leading-none font-semibold', className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot='dialog-description'
+      className={cn('text-muted-foreground text-sm', className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/lib/board/actions.ts
+++ b/lib/board/actions.ts
@@ -1,0 +1,74 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { db } from '@/db'
+import { board } from '@/db/schema'
+import { getCurrentUser } from '@/lib/auth/get-user'
+import { logError } from '@/lib/errors'
+import { createBoardSchema } from './schemas'
+import type { TBoardResult, TCreateBoardInput } from './types'
+
+export async function createBoard(
+  data: TCreateBoardInput,
+): Promise<TBoardResult> {
+  // 1. Verificar autenticación
+  const user = await getCurrentUser()
+
+  if (!user) {
+    return {
+      success: false,
+      error: 'Debes iniciar sesión para crear un tablero',
+    }
+  }
+
+  // 2. Validar datos de entrada
+  const validated = createBoardSchema.safeParse(data)
+
+  if (!validated.success) {
+    const firstError = validated.error.issues[0]
+    return {
+      success: false,
+      error: firstError?.message ?? 'Datos inválidos',
+    }
+  }
+
+  try {
+    // 3. Generar ID único
+    const boardId = crypto.randomUUID()
+
+    // 4. Insertar en base de datos
+    const [newBoard] = await db
+      .insert(board)
+      .values({
+        id: boardId,
+        title: validated.data.title,
+        description: validated.data.description ?? null,
+        backgroundColor: validated.data.backgroundColor,
+        ownerId: user.id,
+      })
+      .returning()
+
+    if (!newBoard) {
+      return {
+        success: false,
+        error: 'Error al crear el tablero',
+      }
+    }
+
+    // 5. Revalidar cache de la página de tableros
+    revalidatePath('/boards')
+    revalidatePath('/')
+
+    return {
+      success: true,
+      data: newBoard,
+    }
+  } catch (error) {
+    logError(error, 'createBoard')
+
+    return {
+      success: false,
+      error: 'Error al crear el tablero. Por favor, intenta de nuevo.',
+    }
+  }
+}

--- a/lib/board/schemas.ts
+++ b/lib/board/schemas.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod'
+
+export const createBoardSchema = z.object({
+  title: z
+    .string()
+    .min(1, 'El título es obligatorio')
+    .min(2, 'El título debe tener al menos 2 caracteres')
+    .max(255, 'El título no puede exceder 255 caracteres')
+    .trim(),
+  description: z
+    .string()
+    .max(1000, 'La descripción no puede exceder 1000 caracteres')
+    .trim()
+    .optional()
+    .nullable(),
+  backgroundColor: z
+    .string()
+    .regex(/^#[0-9A-Fa-f]{6}$/, 'Color inválido')
+    .default('#0079bf'),
+})

--- a/lib/board/types.ts
+++ b/lib/board/types.ts
@@ -1,0 +1,41 @@
+import type { z } from 'zod'
+import type { createBoardSchema } from './schemas'
+
+export type TCreateBoardInput = z.infer<typeof createBoardSchema>
+
+export type TBoard = {
+  id: string
+  title: string
+  description: string | null
+  backgroundColor: string | null
+  backgroundImage: string | null
+  ownerId: string
+  createdAt: Date
+  updatedAt: Date
+}
+
+export type TBoardResult = {
+  success: boolean
+  data?: TBoard
+  error?: string
+}
+
+export type TBoardError =
+  | 'UNAUTHORIZED'
+  | 'VALIDATION_ERROR'
+  | 'DB_ERROR'
+  | 'UNKNOWN_ERROR'
+
+export const BOARD_COLORS = [
+  { name: 'Azul', value: '#0079bf' },
+  { name: 'Naranja', value: '#d29034' },
+  { name: 'Verde', value: '#519839' },
+  { name: 'Rojo', value: '#b04632' },
+  { name: 'Morado', value: '#89609e' },
+  { name: 'Rosa', value: '#cd5a91' },
+  { name: 'Verde Lima', value: '#4bbf6b' },
+  { name: 'Celeste', value: '#00aecc' },
+  { name: 'Gris', value: '#838c91' },
+] as const
+
+export type TBoardColor = (typeof BOARD_COLORS)[number]['value']

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-avatar": "^1.1.11",
+    "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-navigation-menu": "^1.2.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@radix-ui/react-avatar':
         specifier: ^1.1.11
         version: 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.1.16
         version: 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -971,6 +974,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-dialog@1.1.15':
+    resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-direction@1.1.1':
@@ -2547,6 +2563,28 @@ snapshots:
       react: 19.2.1
     optionalDependencies:
       '@types/react': 19.2.7
+
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.7)(react@19.2.1)
+      aria-hidden: 1.2.6
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      react-remove-scroll: 2.7.2(@types/react@19.2.7)(react@19.2.1)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
   '@radix-ui/react-direction@1.1.1(@types/react@19.2.7)(react@19.2.1)':
     dependencies:


### PR DESCRIPTION
- Add CreateBoardDialog component using Shadcn Dialog
- Add board types, Zod schemas, and createBoard server action
- Integrate create board button in navbar for authenticated users
- Include color picker with 9 predefined colors and live preview
- Add client and server-side validation with error feedback

Closes #7