### PR TITLE
feat: implement board detail view with lists and cards

### DIFF
--- a/app/boards/[id]/_components/board-detail-content.tsx
+++ b/app/boards/[id]/_components/board-detail-content.tsx
@@ -1,0 +1,86 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import type { TBoard } from '@/lib/board/types'
+import type { TListWithCards } from '@/lib/list/types'
+import { CardItem } from './card-item'
+import { CreateCardDialog } from './create-card-dialog'
+import { CreateListDialog } from './create-list-dialog'
+
+type TBoardDetailContentProps = {
+  board: TBoard
+  lists: TListWithCards[]
+}
+
+export function BoardDetailContent({ board, lists }: TBoardDetailContentProps) {
+  return (
+    <div className='h-full flex flex-col bg-background'>
+      {/* Board Header with Color Bar */}
+      <div
+        className='border-b-4 px-6 py-4'
+        style={{
+          borderColor: board.backgroundColor ?? '#0079bf',
+        }}
+      >
+        <div className='flex items-center gap-3'>
+          <div
+            className='w-1 h-8 rounded-full'
+            style={{
+              backgroundColor: board.backgroundColor ?? '#0079bf',
+            }}
+          />
+          <div>
+            <h1 className='text-3xl font-display font-bold text-foreground tracking-tight'>
+              {board.title}
+            </h1>
+            {board.description && (
+              <p className='text-muted-foreground text-sm mt-1.5 font-sans'>
+                {board.description}
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Lists Container with Horizontal Scroll */}
+      <div className='flex-1 flex gap-4 overflow-x-auto p-6'>
+        {lists.map((list) => (
+          <div key={list.id} className='shrink-0 w-80'>
+            <Card className='h-full flex flex-col bg-muted/50'>
+              <CardHeader
+                className='pb-3 border-b-2'
+                style={{
+                  borderColor: board.backgroundColor ?? '#0079bf',
+                }}
+              >
+                <CardTitle className='text-lg font-semibold font-sans'>
+                  {list.title}
+                </CardTitle>
+              </CardHeader>
+              <CardContent className='flex-1 flex flex-col gap-2 overflow-y-auto'>
+                {/* Cards */}
+                {list.cards.length > 0 ? (
+                  <div className='space-y-2'>
+                    {list.cards.map((card) => (
+                      <CardItem key={card.id} card={card} />
+                    ))}
+                  </div>
+                ) : (
+                  <p className='text-sm text-muted-foreground text-center py-4'>
+                    No cards yet
+                  </p>
+                )}
+
+                {/* Add Card Button */}
+                <div className='mt-auto pt-2'>
+                  <CreateCardDialog listId={list.id} />
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        ))}
+
+        {/* Add List Button */}
+        <CreateListDialog boardId={board.id} />
+      </div>
+    </div>
+  )
+}

--- a/app/boards/[id]/_components/board-detail-skeleton.tsx
+++ b/app/boards/[id]/_components/board-detail-skeleton.tsx
@@ -1,0 +1,41 @@
+import { Skeleton } from '@/components/ui/skeleton'
+
+export function BoardDetailSkeleton() {
+  return (
+    <div className='h-full flex flex-col bg-background'>
+      {/* Board Header Skeleton */}
+      <div className='border-b-4 border-muted px-6 py-4'>
+        <div className='flex items-center gap-3'>
+          <Skeleton className='w-1 h-8 rounded-full' />
+          <div className='space-y-2'>
+            <Skeleton className='h-8 w-64' />
+            <Skeleton className='h-4 w-48' />
+          </div>
+        </div>
+      </div>
+
+      {/* Lists Container Skeleton */}
+      <div className='flex-1 flex gap-4 overflow-x-auto p-6'>
+        {Array.from({ length: 3 }).map((_, i) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: Static skeleton items
+          <div key={i} className='shrink-0 w-80'>
+            <div className='rounded-lg border bg-muted/50 h-full flex flex-col'>
+              <div className='border-b-2 border-muted p-4'>
+                <Skeleton className='h-6 w-32' />
+              </div>
+              <div className='p-4 space-y-2 flex-1'>
+                {Array.from({ length: 3 }).map((_, j) => (
+                  // biome-ignore lint/suspicious/noArrayIndexKey: Static skeleton items
+                  <div key={j} className='rounded-md border bg-background p-3'>
+                    <Skeleton className='h-4 w-full mb-2' />
+                    <Skeleton className='h-3 w-3/4' />
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/boards/[id]/_components/card-item.tsx
+++ b/app/boards/[id]/_components/card-item.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { Card, CardContent } from '@/components/ui/card'
+import type { TCard } from '@/lib/card/types'
+
+type TCardItemProps = {
+  card: TCard
+}
+
+export function CardItem({ card }: TCardItemProps) {
+  const handleClick = () => {
+    // TODO: Open card detail modal
+    console.log('Card clicked:', card.id)
+  }
+
+  return (
+    <button
+      type='button'
+      className='w-full text-left cursor-pointer hover:shadow-md transition-shadow focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 rounded-lg'
+      onClick={handleClick}
+      aria-label={`Card: ${card.title}`}
+    >
+      <Card>
+        <CardContent className='p-3'>
+          <p className='text-sm font-medium font-sans'>{card.title}</p>
+          {card.description && (
+            <p className='text-xs text-muted-foreground mt-1 line-clamp-2 font-sans'>
+              {card.description}
+            </p>
+          )}
+          {card.dueDate && (
+            <p className='text-xs text-muted-foreground mt-2 font-sans'>
+              Due: {new Date(card.dueDate).toLocaleDateString()}
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    </button>
+  )
+}

--- a/app/boards/[id]/_components/create-card-dialog.tsx
+++ b/app/boards/[id]/_components/create-card-dialog.tsx
@@ -1,0 +1,113 @@
+'use client'
+
+import { Plus } from 'lucide-react'
+import { useId, useState } from 'react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Spinner } from '@/components/ui/spinner'
+import { createCard } from '@/lib/card/actions'
+
+type TCreateCardDialogProps = {
+  listId: string
+}
+
+export function CreateCardDialog({ listId }: TCreateCardDialogProps) {
+  const [isOpen, setIsOpen] = useState(false)
+  const [title, setTitle] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+  const titleId = useId()
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+
+    if (!title.trim()) {
+      toast.error('Card title is required')
+      return
+    }
+
+    setIsLoading(true)
+
+    try {
+      const result = await createCard({ title, listId })
+
+      if (result.success) {
+        toast.success('Card created successfully')
+        setTitle('')
+        setIsOpen(false)
+      } else {
+        toast.error(result.error ?? 'Failed to create card')
+      }
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogTrigger asChild>
+        <Button
+          variant='ghost'
+          size='sm'
+          className='w-full justify-start font-mono'
+        >
+          <Plus className='w-4 h-4 mr-2' />
+          Add a card
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Create New Card</DialogTitle>
+          <DialogDescription>Add a new card to this list</DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit}>
+          <div className='space-y-4 py-4'>
+            <div className='space-y-2'>
+              <Label htmlFor={titleId}>Card Title</Label>
+              <Input
+                id={titleId}
+                placeholder='Enter card title...'
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                disabled={isLoading}
+                autoFocus
+              />
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button
+              type='button'
+              variant='outline'
+              onClick={() => setIsOpen(false)}
+              disabled={isLoading}
+            >
+              Cancel
+            </Button>
+            <Button type='submit' disabled={isLoading}>
+              {isLoading ? (
+                <>
+                  <Spinner className='w-4 h-4 mr-2' />
+                  Creating...
+                </>
+              ) : (
+                'Create Card'
+              )}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/app/boards/[id]/_components/create-list-dialog.tsx
+++ b/app/boards/[id]/_components/create-list-dialog.tsx
@@ -1,0 +1,117 @@
+'use client'
+
+import { Plus } from 'lucide-react'
+import { useId, useState } from 'react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Spinner } from '@/components/ui/spinner'
+import { createList } from '@/lib/list/actions'
+
+type TCreateListDialogProps = {
+  boardId: string
+}
+
+export function CreateListDialog({ boardId }: TCreateListDialogProps) {
+  const [isOpen, setIsOpen] = useState(false)
+  const [title, setTitle] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+  const titleId = useId()
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+
+    if (!title.trim()) {
+      toast.error('List title is required')
+      return
+    }
+
+    setIsLoading(true)
+
+    try {
+      const result = await createList({ title, boardId })
+
+      if (result.success) {
+        toast.success('List created successfully')
+        setTitle('')
+        setIsOpen(false)
+      } else {
+        toast.error(result.error ?? 'Failed to create list')
+      }
+    } catch (_error) {
+      toast.error('An unexpected error occurred')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogTrigger asChild>
+        <Button
+          variant='outline'
+          size='sm'
+          className='shrink-0 w-80 h-auto min-h-[100px] border-dashed font-mono'
+        >
+          <Plus className='w-4 h-4 mr-2' />
+          Add a list
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Create New List</DialogTitle>
+          <DialogDescription>
+            Add a new list to organize your cards
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit}>
+          <div className='space-y-4 py-4'>
+            <div className='space-y-2'>
+              <Label htmlFor={titleId}>List Title</Label>
+              <Input
+                id={titleId}
+                placeholder='Enter list title...'
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                disabled={isLoading}
+                autoFocus
+              />
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button
+              type='button'
+              variant='outline'
+              onClick={() => setIsOpen(false)}
+              disabled={isLoading}
+            >
+              Cancel
+            </Button>
+            <Button type='submit' disabled={isLoading}>
+              {isLoading ? (
+                <>
+                  <Spinner className='w-4 h-4 mr-2' />
+                  Creating...
+                </>
+              ) : (
+                'Create List'
+              )}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -1,0 +1,82 @@
+import { redirect } from 'next/navigation'
+import { Suspense } from 'react'
+import { Navbar } from '@/components/navbar'
+import { getCurrentUser } from '@/lib/auth/get-user'
+import { getBoardById } from '@/lib/board/queries'
+import { getListsByBoardId } from '@/lib/list/queries'
+import { BoardDetailContent } from './_components/board-detail-content'
+import { BoardDetailSkeleton } from './_components/board-detail-skeleton'
+
+type TBoardDetailPageProps = {
+  params: Promise<{ id: string }>
+}
+
+function CenteredMessage({
+  title,
+  description,
+}: {
+  title: string
+  description: string
+}) {
+  return (
+    <div className='flex items-center justify-center min-h-[400px]'>
+      <div className='text-center'>
+        <h2 className='text-2xl font-semibold text-destructive mb-2'>
+          {title}
+        </h2>
+        <p className='text-muted-foreground'>{description}</p>
+      </div>
+    </div>
+  )
+}
+
+async function BoardDetailData({ boardId }: { boardId: string }) {
+  const user = await getCurrentUser()
+
+  if (!user) {
+    redirect('/login')
+  }
+
+  const { success, data: board, error } = await getBoardById(boardId)
+
+  if (!success || !board) {
+    return (
+      <CenteredMessage
+        title='Error loading board'
+        description={error ?? 'Unknown error'}
+      />
+    )
+  }
+
+  // Verify ownership
+  if (board.ownerId !== user.id) {
+    return (
+      <CenteredMessage
+        title='Access Denied'
+        description='You do not have permission to view this board'
+      />
+    )
+  }
+
+  const lists = await getListsByBoardId(boardId)
+
+  return <BoardDetailContent board={board} lists={lists} />
+}
+
+export default async function BoardDetailPage({
+  params,
+}: TBoardDetailPageProps) {
+  const { id } = await params
+
+  return (
+    <div className='min-h-screen bg-background'>
+      <Navbar />
+
+      <main className='h-[calc(100vh-4rem)]'>
+        <Suspense fallback={<BoardDetailSkeleton />}>
+          <BoardDetailData boardId={id} />
+        </Suspense>
+      </main>
+    </div>
+  )
+}

--- a/lib/card/actions.ts
+++ b/lib/card/actions.ts
@@ -1,0 +1,280 @@
+'use server'
+
+import { eq, sql } from 'drizzle-orm'
+import { revalidatePath } from 'next/cache'
+import { db } from '@/db'
+import { card, list } from '@/db/schema'
+import { getCurrentUser } from '@/lib/auth/get-user'
+import { logError } from '@/lib/errors'
+import type {
+  TCreateCardInput,
+  TDeleteCardInput,
+  TUpdateCardInput,
+} from './schemas'
+import { createCardSchema, deleteCardSchema, updateCardSchema } from './schemas'
+
+export type TCardResult = {
+  success: boolean
+  data?: { id: string; title: string }
+  error?: string
+}
+
+export type TDeleteCardResult = {
+  success: boolean
+  error?: string
+}
+
+export async function createCard(data: TCreateCardInput): Promise<TCardResult> {
+  // 1. Verify authentication
+  const user = await getCurrentUser()
+
+  if (!user) {
+    return {
+      success: false,
+      error: 'You must be logged in to create a card',
+    }
+  }
+
+  // 2. Validate input data
+  const validated = createCardSchema.safeParse(data)
+
+  if (!validated.success) {
+    const firstError = validated.error.issues[0]
+    return {
+      success: false,
+      error: firstError?.message ?? 'Invalid data',
+    }
+  }
+
+  try {
+    // 3. Verify list exists and user has access
+    const listRecord = await db.query.list.findFirst({
+      where: eq(list.id, validated.data.listId),
+      with: {
+        board: true,
+      },
+    })
+
+    if (!listRecord) {
+      return {
+        success: false,
+        error: 'List not found',
+      }
+    }
+
+    if (listRecord.board.ownerId !== user.id) {
+      return {
+        success: false,
+        error: 'You do not have permission to add cards to this list',
+      }
+    }
+
+    // 4. Generate unique ID
+    const cardId = crypto.randomUUID()
+
+    // 5. Insert into database with atomic position calculation
+    const newCard = await db.transaction(
+      async (tx) => {
+        // Lock the list row to prevent concurrent card creations
+        await tx
+          .select({ id: list.id })
+          .from(list)
+          .where(eq(list.id, validated.data.listId))
+          .for('update')
+
+        // Get the next position
+        const maxPosition = await tx
+          .select({ max: sql<number>`COALESCE(MAX(${card.position}), -1)` })
+          .from(card)
+          .where(eq(card.listId, validated.data.listId))
+
+        const nextPosition = (maxPosition[0]?.max ?? -1) + 1
+
+        // Insert the new card
+        const [created] = await tx
+          .insert(card)
+          .values({
+            id: cardId,
+            title: validated.data.title,
+            description: validated.data.description ?? null,
+            listId: validated.data.listId,
+            position: nextPosition,
+            dueDate: validated.data.dueDate ?? null,
+          })
+          .returning({ id: card.id, title: card.title })
+
+        return created
+      },
+      {
+        isolationLevel: 'serializable',
+      },
+    )
+
+    // 6. Revalidate board detail page
+    revalidatePath(`/boards/${listRecord.boardId}`)
+
+    return {
+      success: true,
+      data: newCard,
+    }
+  } catch (error) {
+    logError(error, 'Error creating card')
+    return {
+      success: false,
+      error: 'Failed to create card',
+    }
+  }
+}
+
+export async function updateCard(data: TUpdateCardInput): Promise<TCardResult> {
+  // 1. Verify authentication
+  const user = await getCurrentUser()
+
+  if (!user) {
+    return {
+      success: false,
+      error: 'You must be logged in to update a card',
+    }
+  }
+
+  // 2. Validate input data
+  const validated = updateCardSchema.safeParse(data)
+
+  if (!validated.success) {
+    const firstError = validated.error.issues[0]
+    return {
+      success: false,
+      error: firstError?.message ?? 'Invalid data',
+    }
+  }
+
+  try {
+    // 3. Get the card and verify board ownership
+    const cardRecord = await db.query.card.findFirst({
+      where: eq(card.id, validated.data.id),
+      with: {
+        list: {
+          with: {
+            board: true,
+          },
+        },
+      },
+    })
+
+    if (!cardRecord) {
+      return {
+        success: false,
+        error: 'Card not found',
+      }
+    }
+
+    if (cardRecord.list.board.ownerId !== user.id) {
+      return {
+        success: false,
+        error: 'You do not have permission to update this card',
+      }
+    }
+
+    // 4. Update the card
+    const [updatedCard] = await db
+      .update(card)
+      .set({
+        ...(validated.data.title && { title: validated.data.title }),
+        ...(validated.data.description !== undefined && {
+          description: validated.data.description,
+        }),
+        ...(validated.data.position !== undefined && {
+          position: validated.data.position,
+        }),
+        ...(validated.data.dueDate !== undefined && {
+          dueDate: validated.data.dueDate,
+        }),
+        ...(validated.data.listId && { listId: validated.data.listId }),
+      })
+      .where(eq(card.id, validated.data.id))
+      .returning({ id: card.id, title: card.title })
+
+    // 5. Revalidate board detail page
+    revalidatePath(`/boards/${cardRecord.list.boardId}`)
+
+    return {
+      success: true,
+      data: updatedCard,
+    }
+  } catch (error) {
+    logError(error, 'Error updating card')
+    return {
+      success: false,
+      error: 'Failed to update card',
+    }
+  }
+}
+
+export async function deleteCard(
+  data: TDeleteCardInput,
+): Promise<TDeleteCardResult> {
+  // 1. Verify authentication
+  const user = await getCurrentUser()
+
+  if (!user) {
+    return {
+      success: false,
+      error: 'You must be logged in to delete a card',
+    }
+  }
+
+  // 2. Validate input data
+  const validated = deleteCardSchema.safeParse(data)
+
+  if (!validated.success) {
+    const firstError = validated.error.issues[0]
+    return {
+      success: false,
+      error: firstError?.message ?? 'Invalid data',
+    }
+  }
+
+  try {
+    // 3. Get the card and verify board ownership
+    const cardRecord = await db.query.card.findFirst({
+      where: eq(card.id, validated.data.id),
+      with: {
+        list: {
+          with: {
+            board: true,
+          },
+        },
+      },
+    })
+
+    if (!cardRecord) {
+      return {
+        success: false,
+        error: 'Card not found',
+      }
+    }
+
+    if (cardRecord.list.board.ownerId !== user.id) {
+      return {
+        success: false,
+        error: 'You do not have permission to delete this card',
+      }
+    }
+
+    // 4. Delete the card
+    await db.delete(card).where(eq(card.id, validated.data.id))
+
+    // 5. Revalidate board detail page
+    revalidatePath(`/boards/${cardRecord.list.boardId}`)
+
+    return {
+      success: true,
+    }
+  } catch (error) {
+    logError(error, 'Error deleting card')
+    return {
+      success: false,
+      error: 'Failed to delete card',
+    }
+  }
+}

--- a/lib/card/queries.ts
+++ b/lib/card/queries.ts
@@ -1,0 +1,19 @@
+import 'server-only'
+
+import { asc, eq } from 'drizzle-orm'
+import { db } from '@/db'
+import { card } from '@/db/schema'
+import type { TCard } from './types'
+
+export async function getCardsByListId(listId: string): Promise<TCard[]> {
+  return db.query.card.findMany({
+    where: eq(card.listId, listId),
+    orderBy: [asc(card.position)],
+  })
+}
+
+export async function getCardById(cardId: string): Promise<TCard | undefined> {
+  return db.query.card.findFirst({
+    where: eq(card.id, cardId),
+  })
+}

--- a/lib/card/schemas.ts
+++ b/lib/card/schemas.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod'
+
+export const createCardSchema = z.object({
+  title: z
+    .string()
+    .min(1, 'Title is required')
+    .max(255, 'Title must be less than 255 characters'),
+  description: z.string().optional(),
+  listId: z.string().min(1, 'List ID is required'),
+  dueDate: z.date().optional(),
+})
+
+export const updateCardSchema = z.object({
+  id: z.string().min(1, 'Card ID is required'),
+  title: z
+    .string()
+    .min(1, 'Title is required')
+    .max(255, 'Title must be less than 255 characters')
+    .optional(),
+  description: z.string().optional(),
+  position: z.number().int().min(0).optional(),
+  dueDate: z.date().nullable().optional(),
+  listId: z.string().min(1, 'List ID is required').optional(),
+})
+
+export const deleteCardSchema = z.object({
+  id: z.string().min(1, 'Card ID is required'),
+})
+
+export type TCreateCardInput = z.infer<typeof createCardSchema>
+export type TUpdateCardInput = z.infer<typeof updateCardSchema>
+export type TDeleteCardInput = z.infer<typeof deleteCardSchema>

--- a/lib/card/types.ts
+++ b/lib/card/types.ts
@@ -1,0 +1,4 @@
+import type { card } from '@/db/schema'
+
+export type TCard = typeof card.$inferSelect
+export type TCardInsert = typeof card.$inferInsert

--- a/lib/list/actions.ts
+++ b/lib/list/actions.ts
@@ -1,0 +1,260 @@
+'use server'
+
+import { eq, sql } from 'drizzle-orm'
+import { revalidatePath } from 'next/cache'
+import { db } from '@/db'
+import { board, list } from '@/db/schema'
+import { getCurrentUser } from '@/lib/auth/get-user'
+import { logError } from '@/lib/errors'
+import type {
+  TCreateListInput,
+  TDeleteListInput,
+  TUpdateListInput,
+} from './schemas'
+import { createListSchema, deleteListSchema, updateListSchema } from './schemas'
+
+export type TListResult = {
+  success: boolean
+  data?: { id: string; title: string }
+  error?: string
+}
+
+export type TDeleteListResult = {
+  success: boolean
+  error?: string
+}
+
+export async function createList(data: TCreateListInput): Promise<TListResult> {
+  // 1. Verify authentication
+  const user = await getCurrentUser()
+
+  if (!user) {
+    return {
+      success: false,
+      error: 'You must be logged in to create a list',
+    }
+  }
+
+  // 2. Validate input data
+  const validated = createListSchema.safeParse(data)
+
+  if (!validated.success) {
+    const firstError = validated.error.issues[0]
+    return {
+      success: false,
+      error: firstError?.message ?? 'Invalid data',
+    }
+  }
+
+  try {
+    // 3. Verify board ownership
+    const boardRecord = await db.query.board.findFirst({
+      where: eq(board.id, validated.data.boardId),
+    })
+
+    if (!boardRecord) {
+      return {
+        success: false,
+        error: 'Board not found',
+      }
+    }
+
+    if (boardRecord.ownerId !== user.id) {
+      return {
+        success: false,
+        error: 'You do not have permission to add lists to this board',
+      }
+    }
+
+    // 4. Generate unique ID
+    const listId = crypto.randomUUID()
+
+    // 5. Insert into database with atomic position calculation
+    const newList = await db.transaction(
+      async (tx) => {
+        // Lock the board row to prevent concurrent list creations
+        await tx
+          .select({ id: board.id })
+          .from(board)
+          .where(eq(board.id, validated.data.boardId))
+          .for('update')
+
+        // Get the next position
+        const maxPosition = await tx
+          .select({ max: sql<number>`COALESCE(MAX(${list.position}), -1)` })
+          .from(list)
+          .where(eq(list.boardId, validated.data.boardId))
+
+        const nextPosition = (maxPosition[0]?.max ?? -1) + 1
+
+        // Insert the new list
+        const [created] = await tx
+          .insert(list)
+          .values({
+            id: listId,
+            title: validated.data.title,
+            boardId: validated.data.boardId,
+            position: nextPosition,
+          })
+          .returning({ id: list.id, title: list.title })
+
+        return created
+      },
+      {
+        isolationLevel: 'serializable',
+      },
+    )
+
+    // 6. Revalidate board detail page
+    revalidatePath(`/boards/${validated.data.boardId}`)
+
+    return {
+      success: true,
+      data: newList,
+    }
+  } catch (error) {
+    logError(error, 'Error creating list')
+    return {
+      success: false,
+      error: 'Failed to create list',
+    }
+  }
+}
+
+export async function updateList(data: TUpdateListInput): Promise<TListResult> {
+  // 1. Verify authentication
+  const user = await getCurrentUser()
+
+  if (!user) {
+    return {
+      success: false,
+      error: 'You must be logged in to update a list',
+    }
+  }
+
+  // 2. Validate input data
+  const validated = updateListSchema.safeParse(data)
+
+  if (!validated.success) {
+    const firstError = validated.error.issues[0]
+    return {
+      success: false,
+      error: firstError?.message ?? 'Invalid data',
+    }
+  }
+
+  try {
+    // 3. Get the list and verify board ownership
+    const listRecord = await db.query.list.findFirst({
+      where: eq(list.id, validated.data.id),
+      with: {
+        board: true,
+      },
+    })
+
+    if (!listRecord) {
+      return {
+        success: false,
+        error: 'List not found',
+      }
+    }
+
+    if (listRecord.board.ownerId !== user.id) {
+      return {
+        success: false,
+        error: 'You do not have permission to update this list',
+      }
+    }
+
+    // 4. Update the list
+    const [updatedList] = await db
+      .update(list)
+      .set({
+        ...(validated.data.title && { title: validated.data.title }),
+        ...(validated.data.position !== undefined && {
+          position: validated.data.position,
+        }),
+      })
+      .where(eq(list.id, validated.data.id))
+      .returning({ id: list.id, title: list.title })
+
+    // 5. Revalidate board detail page
+    revalidatePath(`/boards/${listRecord.boardId}`)
+
+    return {
+      success: true,
+      data: updatedList,
+    }
+  } catch (error) {
+    logError(error, 'Error updating list')
+    return {
+      success: false,
+      error: 'Failed to update list',
+    }
+  }
+}
+
+export async function deleteList(
+  data: TDeleteListInput,
+): Promise<TDeleteListResult> {
+  // 1. Verify authentication
+  const user = await getCurrentUser()
+
+  if (!user) {
+    return {
+      success: false,
+      error: 'You must be logged in to delete a list',
+    }
+  }
+
+  // 2. Validate input data
+  const validated = deleteListSchema.safeParse(data)
+
+  if (!validated.success) {
+    const firstError = validated.error.issues[0]
+    return {
+      success: false,
+      error: firstError?.message ?? 'Invalid data',
+    }
+  }
+
+  try {
+    // 3. Get the list and verify board ownership
+    const listRecord = await db.query.list.findFirst({
+      where: eq(list.id, validated.data.id),
+      with: {
+        board: true,
+      },
+    })
+
+    if (!listRecord) {
+      return {
+        success: false,
+        error: 'List not found',
+      }
+    }
+
+    if (listRecord.board.ownerId !== user.id) {
+      return {
+        success: false,
+        error: 'You do not have permission to delete this list',
+      }
+    }
+
+    // 4. Delete the list (cards will be cascade deleted)
+    await db.delete(list).where(eq(list.id, validated.data.id))
+
+    // 5. Revalidate board detail page
+    revalidatePath(`/boards/${listRecord.boardId}`)
+
+    return {
+      success: true,
+    }
+  } catch (error) {
+    logError(error, 'Error deleting list')
+    return {
+      success: false,
+      error: 'Failed to delete list',
+    }
+  }
+}

--- a/lib/list/queries.ts
+++ b/lib/list/queries.ts
@@ -1,0 +1,37 @@
+import 'server-only'
+
+import { asc, eq } from 'drizzle-orm'
+import { unstable_cache } from 'next/cache'
+import { db } from '@/db'
+import { card, list } from '@/db/schema'
+import type { TList, TListWithCards } from './types'
+
+async function _getListsByBoardId(boardId: string): Promise<TListWithCards[]> {
+  const lists = await db.query.list.findMany({
+    where: eq(list.boardId, boardId),
+    orderBy: [asc(list.position)],
+    with: {
+      cards: {
+        orderBy: [asc(card.position)],
+      },
+    },
+  })
+
+  return lists
+}
+
+export const getListsByBoardId = (boardId: string) =>
+  unstable_cache(
+    async () => _getListsByBoardId(boardId),
+    [`lists-by-board-${boardId}`],
+    {
+      tags: [`board:${boardId}:lists`],
+      revalidate: false, // Only revalidate on-demand via revalidateTag
+    },
+  )()
+
+export async function getListById(listId: string): Promise<TList | undefined> {
+  return db.query.list.findFirst({
+    where: eq(list.id, listId),
+  })
+}

--- a/lib/list/schemas.ts
+++ b/lib/list/schemas.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod'
+
+export const createListSchema = z.object({
+  title: z
+    .string()
+    .min(1, 'Title is required')
+    .max(255, 'Title must be less than 255 characters'),
+  boardId: z.string().min(1, 'Board ID is required'),
+})
+
+export const updateListSchema = z.object({
+  id: z.string().min(1, 'List ID is required'),
+  title: z
+    .string()
+    .min(1, 'Title is required')
+    .max(255, 'Title must be less than 255 characters')
+    .optional(),
+  position: z.number().int().min(0).optional(),
+})
+
+export const deleteListSchema = z.object({
+  id: z.string().min(1, 'List ID is required'),
+})
+
+export type TCreateListInput = z.infer<typeof createListSchema>
+export type TUpdateListInput = z.infer<typeof updateListSchema>
+export type TDeleteListInput = z.infer<typeof deleteListSchema>

--- a/lib/list/types.ts
+++ b/lib/list/types.ts
@@ -1,0 +1,9 @@
+import type { list } from '@/db/schema'
+import type { TCard } from '@/lib/card/types'
+
+export type TList = typeof list.$inferSelect
+export type TListInsert = typeof list.$inferInsert
+
+export type TListWithCards = TList & {
+  cards: TCard[]
+}


### PR DESCRIPTION
Closes #13

## Features
- Board detail page with SSR and Suspense
- Create and display lists with horizontal scrolling
- Create and display cards within lists
- Loading skeletons for better UX
- Keyboard navigation support for cards

## Data Layer
- List module: types, schemas, queries, and actions
- Card module: types, schemas, queries, and actions
- Database transactions for atomic position calculations
- Input validation with Zod schemas
- Authentication and authorization checks

## UI/UX Improvements
- Elegant header with board color references
- Subtle color indicators on list headers
- Horizontal scroll for lists
- Responsive card layout
- Custom fonts: Playfair Display for titles, Inter for content, JetBrains Mono for action buttons
- Accessible keyboard navigation

## Performance & Security
- Atomic transactions to prevent race conditions
- Cache strategy with unstable_cache
- Proper error handling and validation
- Protection against concurrent insertions