### PR TITLE
feat: add comprehensive unit test suite with 70% coverage

### DIFF
--- a/__tests__/components/ui/button.test.tsx
+++ b/__tests__/components/ui/button.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { Button } from '@/components/ui/button'
+
+describe('Button Component', () => {
+  it('renders with default props', () => {
+    render(<Button>Click me</Button>)
+    const button = screen.getByRole('button', { name: 'Click me' })
+    expect(button).toBeDefined()
+    expect(button.getAttribute('data-variant')).toBe('default')
+    expect(button.getAttribute('data-size')).toBe('default')
+  })
+
+  it('renders with different variants', () => {
+    const variants = [
+      'default',
+      'destructive',
+      'outline',
+      'secondary',
+      'ghost',
+      'link',
+    ] as const
+
+    for (const variant of variants) {
+      const { container } = render(<Button variant={variant}>Button</Button>)
+      const button = container.querySelector('button')
+      expect(button?.getAttribute('data-variant')).toBe(variant)
+    }
+  })
+
+  it('renders with different sizes', () => {
+    const sizes = ['default', 'sm', 'lg', 'icon'] as const
+
+    for (const size of sizes) {
+      const { container } = render(<Button size={size}>Button</Button>)
+      const button = container.querySelector('button')
+      expect(button?.getAttribute('data-size')).toBe(size)
+    }
+  })
+
+  it('applies custom className', () => {
+    render(<Button className='custom-class'>Button</Button>)
+    const button = screen.getByRole('button')
+    expect(button.classList.contains('custom-class')).toBe(true)
+  })
+
+  it('passes additional props', () => {
+    render(
+      <Button type='submit' disabled>
+        Button
+      </Button>,
+    )
+    const button = screen.getByRole('button')
+    expect(button.getAttribute('type')).toBe('submit')
+    expect(button.hasAttribute('disabled')).toBe(true)
+  })
+
+  it('renders as child component with asChild', () => {
+    render(
+      <Button asChild>
+        <a href='/test'>Link Button</a>
+      </Button>,
+    )
+    const link = screen.getByRole('link', { name: 'Link Button' })
+    expect(link).toBeDefined()
+    expect(link.getAttribute('href')).toBe('/test')
+  })
+
+  it('has data-slot attribute', () => {
+    render(<Button>Button</Button>)
+    const button = screen.getByRole('button')
+    expect(button.getAttribute('data-slot')).toBe('button')
+  })
+
+  it('renders children correctly', () => {
+    render(
+      <Button>
+        <span>Icon</span>
+        Text
+      </Button>,
+    )
+    expect(screen.getByText('Icon')).toBeDefined()
+    expect(screen.getByText('Text')).toBeDefined()
+  })
+})

--- a/__tests__/components/ui/input.test.tsx
+++ b/__tests__/components/ui/input.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+import { Input } from '@/components/ui/input'
+
+describe('Input Component', () => {
+  it('renders with default props', () => {
+    render(<Input />)
+    const input = screen.getByRole('textbox')
+    expect(input).toBeDefined()
+    expect(input.getAttribute('data-slot')).toBe('input')
+  })
+
+  it('renders with type text by default', () => {
+    render(<Input />)
+    const input = screen.getByRole('textbox')
+    expect(input.getAttribute('type')).toBeNull() // type text doesn't show in role textbox
+  })
+
+  it('renders with different types', () => {
+    const { container } = render(<Input type='email' />)
+    const input = container.querySelector('input')
+    expect(input?.getAttribute('type')).toBe('email')
+  })
+
+  it('renders with password type', () => {
+    const { container } = render(<Input type='password' />)
+    const input = container.querySelector('input')
+    expect(input?.getAttribute('type')).toBe('password')
+  })
+
+  it('applies custom className', () => {
+    render(<Input className='custom-class' />)
+    const input = screen.getByRole('textbox')
+    expect(input.classList.contains('custom-class')).toBe(true)
+  })
+
+  it('passes placeholder prop', () => {
+    render(<Input placeholder='Enter text' />)
+    const input = screen.getByPlaceholderText('Enter text')
+    expect(input).toBeDefined()
+  })
+
+  it('passes value prop', () => {
+    render(<Input value='test value' readOnly />)
+    const input = screen.getByRole('textbox') as HTMLInputElement
+    expect(input.value).toBe('test value')
+  })
+
+  it('passes disabled prop', () => {
+    render(<Input disabled />)
+    const input = screen.getByRole('textbox')
+    expect(input.hasAttribute('disabled')).toBe(true)
+  })
+
+  it('passes required prop', () => {
+    render(<Input required />)
+    const input = screen.getByRole('textbox')
+    expect(input.hasAttribute('required')).toBe(true)
+  })
+
+  it('passes name prop', () => {
+    render(<Input name='username' />)
+    const input = screen.getByRole('textbox')
+    expect(input.getAttribute('name')).toBe('username')
+  })
+
+  it('accepts user input', async () => {
+    const user = userEvent.setup()
+    render(<Input />)
+    const input = screen.getByRole('textbox') as HTMLInputElement
+
+    await user.type(input, 'Hello World')
+    expect(input.value).toBe('Hello World')
+  })
+
+  it('renders with aria-invalid for error state', () => {
+    render(<Input aria-invalid='true' />)
+    const input = screen.getByRole('textbox')
+    expect(input.getAttribute('aria-invalid')).toBe('true')
+  })
+
+  it('renders with id prop', () => {
+    render(<Input id='my-input' />)
+    const input = screen.getByRole('textbox')
+    expect(input.getAttribute('id')).toBe('my-input')
+  })
+})

--- a/__tests__/lib/auth/schemas.test.ts
+++ b/__tests__/lib/auth/schemas.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest'
+import { signInSchema, signUpSchema } from '@/lib/auth/schemas'
+
+describe('Auth Schemas', () => {
+  describe('signInSchema', () => {
+    it('validates correct login data', () => {
+      const result = signInSchema.safeParse({
+        email: 'test@example.com',
+        password: 'password123',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('transforms email to lowercase', () => {
+      const result = signInSchema.safeParse({
+        email: 'Test@EXAMPLE.com',
+        password: 'password123',
+      })
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.email).toBe('test@example.com')
+      }
+    })
+
+    it('rejects empty email', () => {
+      const result = signInSchema.safeParse({
+        email: '',
+        password: 'password123',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe('El email es obligatorio')
+      }
+    })
+
+    it('rejects invalid email format', () => {
+      const result = signInSchema.safeParse({
+        email: 'not-an-email',
+        password: 'password123',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe('Email inválido')
+      }
+    })
+
+    it('rejects empty password', () => {
+      const result = signInSchema.safeParse({
+        email: 'test@example.com',
+        password: '',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe(
+          'La contraseña es obligatoria',
+        )
+      }
+    })
+  })
+
+  describe('signUpSchema', () => {
+    it('validates correct registration data', () => {
+      const result = signUpSchema.safeParse({
+        name: 'Test User',
+        email: 'test@example.com',
+        password: 'password123',
+        confirmPassword: 'password123',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects name shorter than 2 characters', () => {
+      const result = signUpSchema.safeParse({
+        name: 'A',
+        email: 'test@example.com',
+        password: 'password123',
+        confirmPassword: 'password123',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe(
+          'El nombre debe tener al menos 2 caracteres',
+        )
+      }
+    })
+
+    it('rejects name longer than 100 characters', () => {
+      const result = signUpSchema.safeParse({
+        name: 'A'.repeat(101),
+        email: 'test@example.com',
+        password: 'password123',
+        confirmPassword: 'password123',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe(
+          'El nombre no puede exceder 100 caracteres',
+        )
+      }
+    })
+
+    it('rejects password shorter than 8 characters', () => {
+      const result = signUpSchema.safeParse({
+        name: 'Test User',
+        email: 'test@example.com',
+        password: '1234567',
+        confirmPassword: '1234567',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe(
+          'La contraseña debe tener al menos 8 caracteres',
+        )
+      }
+    })
+
+    it('rejects password longer than 100 characters', () => {
+      const longPassword = 'A'.repeat(101)
+      const result = signUpSchema.safeParse({
+        name: 'Test User',
+        email: 'test@example.com',
+        password: longPassword,
+        confirmPassword: longPassword,
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe(
+          'La contraseña no puede exceder 100 caracteres',
+        )
+      }
+    })
+
+    it('rejects mismatched passwords', () => {
+      const result = signUpSchema.safeParse({
+        name: 'Test User',
+        email: 'test@example.com',
+        password: 'password123',
+        confirmPassword: 'different123',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe(
+          'Las contraseñas no coinciden',
+        )
+      }
+    })
+
+    it('trims name and transforms email to lowercase', () => {
+      const result = signUpSchema.safeParse({
+        name: '  Test User  ',
+        email: 'Test@Example.com',
+        password: 'password123',
+        confirmPassword: 'password123',
+      })
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.name).toBe('Test User')
+        expect(result.data.email).toBe('test@example.com')
+      }
+    })
+  })
+})

--- a/__tests__/lib/board/actions.test.ts
+++ b/__tests__/lib/board/actions.test.ts
@@ -1,0 +1,337 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Use vi.hoisted to define mock functions before they're used in vi.mock
+const { mockInsert, mockUpdate, mockDelete, mockSelect, mockGetCurrentUser } =
+  vi.hoisted(() => ({
+    mockInsert: vi.fn(),
+    mockUpdate: vi.fn(),
+    mockDelete: vi.fn(),
+    mockSelect: vi.fn(),
+    mockGetCurrentUser: vi.fn(),
+  }))
+
+// Mock the database
+vi.mock('@/db', () => ({
+  db: {
+    insert: mockInsert,
+    update: mockUpdate,
+    delete: mockDelete,
+    select: mockSelect,
+  },
+}))
+
+// Mock auth
+vi.mock('@/lib/auth/get-user', () => ({
+  getCurrentUser: mockGetCurrentUser,
+}))
+
+// Mock errors
+vi.mock('@/lib/errors', () => ({
+  logError: vi.fn(),
+}))
+
+// Import after mocking
+import {
+  createBoard,
+  deleteBoard,
+  updateBoard,
+  updateBoardPrivacy,
+} from '@/lib/board/actions'
+
+describe('Board Actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('createBoard', () => {
+    it('returns error when user is not authenticated', async () => {
+      mockGetCurrentUser.mockResolvedValue(null)
+
+      const result = await createBoard({
+        title: 'My Board',
+        backgroundColor: '#0079bf',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('Debes iniciar sesión para crear un tablero')
+    })
+
+    it('returns error for invalid data', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+
+      const result = await createBoard({
+        title: '', // Invalid empty title
+        backgroundColor: '#0079bf',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('El título es obligatorio')
+    })
+
+    it('creates board successfully', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+
+      const mockBoard = {
+        id: 'board-123',
+        title: 'My Board',
+        description: null,
+        backgroundColor: '#0079bf',
+        ownerId: 'user-123',
+      }
+
+      mockInsert.mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([mockBoard]),
+        }),
+      })
+
+      const result = await createBoard({
+        title: 'My Board',
+        backgroundColor: '#0079bf',
+      })
+
+      expect(result.success).toBe(true)
+      expect(result.data).toEqual(mockBoard)
+    })
+
+    it('handles database error', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+
+      mockInsert.mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockRejectedValue(new Error('DB Error')),
+        }),
+      })
+
+      const result = await createBoard({
+        title: 'My Board',
+        backgroundColor: '#0079bf',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe(
+        'Error al crear el tablero. Por favor, intenta de nuevo.',
+      )
+    })
+  })
+
+  describe('deleteBoard', () => {
+    it('returns error when user is not authenticated', async () => {
+      mockGetCurrentUser.mockResolvedValue(null)
+
+      const result = await deleteBoard({
+        boardId: '123e4567-e89b-12d3-a456-426614174000',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('Debes iniciar sesión para eliminar un tablero')
+    })
+
+    it('returns error for invalid boardId', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+
+      const result = await deleteBoard({
+        boardId: 'invalid-uuid',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('ID de tablero inválido')
+    })
+
+    it('returns error when board does not exist', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+
+      mockSelect.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      })
+
+      const result = await deleteBoard({
+        boardId: '123e4567-e89b-12d3-a456-426614174000',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('El tablero no existe')
+    })
+
+    it('returns error when user is not owner', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+
+      mockSelect.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([
+              {
+                id: '123e4567-e89b-12d3-a456-426614174000',
+                ownerId: 'other-user',
+              },
+            ]),
+          }),
+        }),
+      })
+
+      const result = await deleteBoard({
+        boardId: '123e4567-e89b-12d3-a456-426614174000',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('No tienes permiso para eliminar este tablero')
+    })
+
+    it('deletes board successfully', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+
+      mockSelect.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([
+              {
+                id: '123e4567-e89b-12d3-a456-426614174000',
+                ownerId: 'user-123',
+              },
+            ]),
+          }),
+        }),
+      })
+
+      mockDelete.mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      })
+
+      const result = await deleteBoard({
+        boardId: '123e4567-e89b-12d3-a456-426614174000',
+      })
+
+      expect(result.success).toBe(true)
+    })
+  })
+
+  describe('updateBoard', () => {
+    it('returns error when user is not authenticated', async () => {
+      mockGetCurrentUser.mockResolvedValue(null)
+
+      const result = await updateBoard({
+        boardId: '123e4567-e89b-12d3-a456-426614174000',
+        title: 'Updated',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('Debes iniciar sesión para editar un tablero')
+    })
+
+    it('returns error when no fields to update', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+
+      mockSelect.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([
+              {
+                id: '123e4567-e89b-12d3-a456-426614174000',
+                ownerId: 'user-123',
+              },
+            ]),
+          }),
+        }),
+      })
+
+      const result = await updateBoard({
+        boardId: '123e4567-e89b-12d3-a456-426614174000',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('No se proporcionaron campos para actualizar')
+    })
+
+    it('updates board successfully', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+
+      const mockBoard = {
+        id: '123e4567-e89b-12d3-a456-426614174000',
+        title: 'Updated Title',
+        ownerId: 'user-123',
+      }
+
+      mockSelect.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([mockBoard]),
+          }),
+        }),
+      })
+
+      mockUpdate.mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([mockBoard]),
+          }),
+        }),
+      })
+
+      const result = await updateBoard({
+        boardId: '123e4567-e89b-12d3-a456-426614174000',
+        title: 'Updated Title',
+      })
+
+      expect(result.success).toBe(true)
+      expect(result.data?.title).toBe('Updated Title')
+    })
+  })
+
+  describe('updateBoardPrivacy', () => {
+    it('returns error when user is not authenticated', async () => {
+      mockGetCurrentUser.mockResolvedValue(null)
+
+      const result = await updateBoardPrivacy({
+        boardId: '123e4567-e89b-12d3-a456-426614174000',
+        isPrivate: 'private',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe(
+        'Debes iniciar sesión para cambiar la privacidad del tablero',
+      )
+    })
+
+    it('returns error for invalid privacy value', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+
+      const result = await updateBoardPrivacy({
+        boardId: '123e4567-e89b-12d3-a456-426614174000',
+        // @ts-expect-error Testing invalid value
+        isPrivate: 'invalid',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('Valor de privacidad inválido')
+    })
+
+    it('updates privacy successfully', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+
+      const mockBoard = {
+        id: '123e4567-e89b-12d3-a456-426614174000',
+        isPrivate: 'private',
+        ownerId: 'user-123',
+      }
+
+      mockUpdate.mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([mockBoard]),
+          }),
+        }),
+      })
+
+      const result = await updateBoardPrivacy({
+        boardId: '123e4567-e89b-12d3-a456-426614174000',
+        isPrivate: 'private',
+      })
+
+      expect(result.success).toBe(true)
+    })
+  })
+})

--- a/__tests__/lib/board/schemas.test.ts
+++ b/__tests__/lib/board/schemas.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createBoardSchema,
+  deleteBoardSchema,
+  updateBoardPrivacySchema,
+  updateBoardSchema,
+} from '@/lib/board/schemas'
+
+describe('Board Schemas', () => {
+  describe('createBoardSchema', () => {
+    it('validates correct board data', () => {
+      const result = createBoardSchema.safeParse({
+        title: 'My Board',
+        description: 'A test board',
+        backgroundColor: '#FF5733',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('uses default background color', () => {
+      const result = createBoardSchema.safeParse({
+        title: 'My Board',
+      })
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.backgroundColor).toBeDefined()
+      }
+    })
+
+    it('rejects empty title', () => {
+      const result = createBoardSchema.safeParse({
+        title: '',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe('El título es obligatorio')
+      }
+    })
+
+    it('rejects title shorter than 2 characters', () => {
+      const result = createBoardSchema.safeParse({
+        title: 'A',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe(
+          'El título debe tener al menos 2 caracteres',
+        )
+      }
+    })
+
+    it('rejects title longer than 255 characters', () => {
+      const result = createBoardSchema.safeParse({
+        title: 'A'.repeat(256),
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe(
+          'El título no puede exceder 255 caracteres',
+        )
+      }
+    })
+
+    it('rejects description longer than 1000 characters', () => {
+      const result = createBoardSchema.safeParse({
+        title: 'My Board',
+        description: 'A'.repeat(1001),
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe(
+          'La descripción no puede exceder 1000 caracteres',
+        )
+      }
+    })
+
+    it('rejects invalid hex color', () => {
+      const result = createBoardSchema.safeParse({
+        title: 'My Board',
+        backgroundColor: 'not-a-color',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe('Color inválido')
+      }
+    })
+
+    it('rejects hex color with wrong format', () => {
+      const result = createBoardSchema.safeParse({
+        title: 'My Board',
+        backgroundColor: '#FFF', // 3-digit hex not allowed
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('accepts valid 6-digit hex colors', () => {
+      const colors = ['#000000', '#FFFFFF', '#ff5733', '#ABC123']
+      for (const color of colors) {
+        const result = createBoardSchema.safeParse({
+          title: 'My Board',
+          backgroundColor: color,
+        })
+        expect(result.success).toBe(true)
+      }
+    })
+
+    it('accepts null description', () => {
+      const result = createBoardSchema.safeParse({
+        title: 'My Board',
+        description: null,
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('trims title and description', () => {
+      const result = createBoardSchema.safeParse({
+        title: '  My Board  ',
+        description: '  A description  ',
+      })
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.title).toBe('My Board')
+        expect(result.data.description).toBe('A description')
+      }
+    })
+  })
+
+  describe('updateBoardSchema', () => {
+    it('validates correct update data', () => {
+      const result = updateBoardSchema.safeParse({
+        boardId: '123e4567-e89b-12d3-a456-426614174000',
+        title: 'Updated Title',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects invalid UUID for boardId', () => {
+      const result = updateBoardSchema.safeParse({
+        boardId: 'not-a-uuid',
+        title: 'Updated Title',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe('ID de tablero inválido')
+      }
+    })
+
+    it('allows optional fields', () => {
+      const result = updateBoardSchema.safeParse({
+        boardId: '123e4567-e89b-12d3-a456-426614174000',
+      })
+      expect(result.success).toBe(true)
+    })
+  })
+
+  describe('deleteBoardSchema', () => {
+    it('validates correct delete data', () => {
+      const result = deleteBoardSchema.safeParse({
+        boardId: '123e4567-e89b-12d3-a456-426614174000',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects invalid UUID', () => {
+      const result = deleteBoardSchema.safeParse({
+        boardId: 'invalid',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe('ID de tablero inválido')
+      }
+    })
+  })
+
+  describe('updateBoardPrivacySchema', () => {
+    it('validates public privacy setting', () => {
+      const result = updateBoardPrivacySchema.safeParse({
+        boardId: '123e4567-e89b-12d3-a456-426614174000',
+        isPrivate: 'public',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('validates private privacy setting', () => {
+      const result = updateBoardPrivacySchema.safeParse({
+        boardId: '123e4567-e89b-12d3-a456-426614174000',
+        isPrivate: 'private',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects invalid privacy value', () => {
+      const result = updateBoardPrivacySchema.safeParse({
+        boardId: '123e4567-e89b-12d3-a456-426614174000',
+        isPrivate: 'invalid',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe(
+          'Valor de privacidad inválido',
+        )
+      }
+    })
+  })
+})

--- a/__tests__/lib/card/actions.test.ts
+++ b/__tests__/lib/card/actions.test.ts
@@ -1,0 +1,376 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Use vi.hoisted to define mock functions before they're used in vi.mock
+const {
+  mockQuery,
+  mockInsert,
+  mockUpdate,
+  mockDelete,
+  mockSelect,
+  mockTransaction,
+  mockGetCurrentUser,
+} = vi.hoisted(() => ({
+  mockQuery: {
+    card: {
+      findFirst: vi.fn(),
+    },
+    list: {
+      findFirst: vi.fn(),
+    },
+  },
+  mockInsert: vi.fn(),
+  mockUpdate: vi.fn(),
+  mockDelete: vi.fn(),
+  mockSelect: vi.fn(),
+  mockTransaction: vi.fn(),
+  mockGetCurrentUser: vi.fn(),
+}))
+
+// Mock the database
+vi.mock('@/db', () => ({
+  db: {
+    query: mockQuery,
+    insert: mockInsert,
+    update: mockUpdate,
+    delete: mockDelete,
+    select: mockSelect,
+    transaction: mockTransaction,
+  },
+}))
+
+// Mock auth
+vi.mock('@/lib/auth/get-user', () => ({
+  getCurrentUser: mockGetCurrentUser,
+}))
+
+// Mock errors
+vi.mock('@/lib/errors', () => ({
+  logError: vi.fn(),
+}))
+
+// Import after mocking
+import {
+  createCard,
+  deleteCard,
+  moveCardAction,
+  updateCard,
+} from '@/lib/card/actions'
+
+describe('Card Actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('createCard', () => {
+    it('returns error when user is not authenticated', async () => {
+      mockGetCurrentUser.mockResolvedValue(null)
+
+      const result = await createCard({
+        title: 'My Card',
+        listId: 'list-123',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('Debes iniciar sesión para crear una tarjeta')
+    })
+
+    it('returns error for invalid data - empty title', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+
+      const result = await createCard({
+        title: '',
+        listId: 'list-123',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('El título es obligatorio')
+    })
+
+    it('returns error for invalid data - empty listId', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+
+      const result = await createCard({
+        title: 'My Card',
+        listId: '',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('El ID de lista es obligatorio')
+    })
+
+    it('returns error when list not found', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+      mockQuery.list.findFirst.mockResolvedValue(null)
+
+      const result = await createCard({
+        title: 'My Card',
+        listId: 'list-123',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('Lista no encontrada')
+    })
+
+    it('returns error when user is not board owner', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+      mockQuery.list.findFirst.mockResolvedValue({
+        id: 'list-123',
+        board: { ownerId: 'other-user' },
+      })
+
+      const result = await createCard({
+        title: 'My Card',
+        listId: 'list-123',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe(
+        'No tienes permiso para añadir tarjetas a esta lista',
+      )
+    })
+
+    it('creates card successfully', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+      mockQuery.list.findFirst.mockResolvedValue({
+        id: 'list-123',
+        boardId: 'board-123',
+        board: { ownerId: 'user-123' },
+      })
+
+      const mockCard = { id: 'card-123', title: 'My Card' }
+
+      mockTransaction.mockImplementation(async (callback) => {
+        const lockQueryMock = {
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              for: vi.fn().mockResolvedValue([{ id: 'list-123' }]),
+            }),
+          }),
+        }
+
+        const maxPosQueryMock = {
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ max: 0 }]),
+          }),
+        }
+
+        const tx = {
+          select: vi
+            .fn()
+            .mockReturnValueOnce(lockQueryMock)
+            .mockReturnValueOnce(maxPosQueryMock),
+          insert: vi.fn().mockReturnValue({
+            values: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([mockCard]),
+            }),
+          }),
+        }
+        return callback(tx)
+      })
+
+      const result = await createCard({
+        title: 'My Card',
+        listId: 'list-123',
+      })
+
+      expect(result.success).toBe(true)
+    })
+  })
+
+  describe('updateCard', () => {
+    it('returns error when user is not authenticated', async () => {
+      mockGetCurrentUser.mockResolvedValue(null)
+
+      const result = await updateCard({
+        id: 'card-123',
+        title: 'Updated',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe(
+        'Debes iniciar sesión para actualizar una tarjeta',
+      )
+    })
+
+    it('returns error for invalid data', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+
+      const result = await updateCard({
+        id: '',
+        title: 'Updated',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('El ID de tarjeta es obligatorio')
+    })
+
+    it('returns error when card not found', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+      mockQuery.card.findFirst.mockResolvedValue(null)
+
+      const result = await updateCard({
+        id: 'card-123',
+        title: 'Updated',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('Tarjeta no encontrada')
+    })
+
+    it('returns error when user is not board owner', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+      mockQuery.card.findFirst.mockResolvedValue({
+        id: 'card-123',
+        list: { board: { ownerId: 'other-user' } },
+      })
+
+      const result = await updateCard({
+        id: 'card-123',
+        title: 'Updated',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe(
+        'No tienes permiso para actualizar esta tarjeta',
+      )
+    })
+
+    it('updates card successfully', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+      mockQuery.card.findFirst.mockResolvedValue({
+        id: 'card-123',
+        listId: 'list-123',
+        list: { boardId: 'board-123', board: { ownerId: 'user-123' } },
+      })
+
+      const mockCard = { id: 'card-123', title: 'Updated' }
+      mockUpdate.mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([mockCard]),
+          }),
+        }),
+      })
+
+      const result = await updateCard({
+        id: 'card-123',
+        title: 'Updated',
+      })
+
+      expect(result.success).toBe(true)
+      expect(result.data?.title).toBe('Updated')
+    })
+  })
+
+  describe('deleteCard', () => {
+    it('returns error when user is not authenticated', async () => {
+      mockGetCurrentUser.mockResolvedValue(null)
+
+      const result = await deleteCard({
+        id: 'card-123',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe(
+        'Debes iniciar sesión para eliminar una tarjeta',
+      )
+    })
+
+    it('returns error for invalid data', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+
+      const result = await deleteCard({
+        id: '',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('El ID de tarjeta es obligatorio')
+    })
+
+    it('returns error when card not found', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+      mockQuery.card.findFirst.mockResolvedValue(null)
+
+      const result = await deleteCard({
+        id: 'card-123',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('Tarjeta no encontrada')
+    })
+
+    it('returns error when user is not board owner', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+      mockQuery.card.findFirst.mockResolvedValue({
+        id: 'card-123',
+        list: { board: { ownerId: 'other-user' } },
+      })
+
+      const result = await deleteCard({
+        id: 'card-123',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('No tienes permiso para eliminar esta tarjeta')
+    })
+
+    it('deletes card successfully', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+      mockQuery.card.findFirst.mockResolvedValue({
+        id: 'card-123',
+        list: { boardId: 'board-123', board: { ownerId: 'user-123' } },
+      })
+
+      mockDelete.mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      })
+
+      const result = await deleteCard({
+        id: 'card-123',
+      })
+
+      expect(result.success).toBe(true)
+    })
+  })
+
+  describe('moveCardAction', () => {
+    it('returns error when user is not authenticated', async () => {
+      mockGetCurrentUser.mockResolvedValue(null)
+
+      const result = await moveCardAction({
+        cardId: 'card-123',
+        targetListId: 'list-456',
+        position: 0,
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('Debes iniciar sesión para mover una tarjeta')
+    })
+
+    it('returns error for invalid data', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+
+      const result = await moveCardAction({
+        cardId: '',
+        targetListId: 'list-456',
+        position: 0,
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('El ID de tarjeta es obligatorio')
+    })
+
+    it('returns error for negative position', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+
+      const result = await moveCardAction({
+        cardId: 'card-123',
+        targetListId: 'list-456',
+        position: -1,
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('La posición debe ser un número no negativo')
+    })
+  })
+})

--- a/__tests__/lib/card/schemas.test.ts
+++ b/__tests__/lib/card/schemas.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createCardSchema,
+  deleteCardSchema,
+  moveCardSchema,
+  updateCardSchema,
+} from '@/lib/card/schemas'
+
+describe('Card Schemas', () => {
+  describe('createCardSchema', () => {
+    it('validates correct card data', () => {
+      const result = createCardSchema.safeParse({
+        title: 'My Card',
+        listId: 'list-123',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('accepts optional description', () => {
+      const result = createCardSchema.safeParse({
+        title: 'My Card',
+        listId: 'list-123',
+        description: 'A test card',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('accepts optional dueDate', () => {
+      const result = createCardSchema.safeParse({
+        title: 'My Card',
+        listId: 'list-123',
+        dueDate: new Date(),
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects empty title', () => {
+      const result = createCardSchema.safeParse({
+        title: '',
+        listId: 'list-123',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe('El título es obligatorio')
+      }
+    })
+
+    it('rejects title longer than 255 characters', () => {
+      const result = createCardSchema.safeParse({
+        title: 'A'.repeat(256),
+        listId: 'list-123',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe(
+          'El título debe tener menos de 255 caracteres',
+        )
+      }
+    })
+
+    it('rejects empty listId', () => {
+      const result = createCardSchema.safeParse({
+        title: 'My Card',
+        listId: '',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe(
+          'El ID de lista es obligatorio',
+        )
+      }
+    })
+  })
+
+  describe('updateCardSchema', () => {
+    it('validates correct update data', () => {
+      const result = updateCardSchema.safeParse({
+        id: 'card-123',
+        title: 'Updated Title',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects empty id', () => {
+      const result = updateCardSchema.safeParse({
+        id: '',
+        title: 'Updated Title',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe(
+          'El ID de tarjeta es obligatorio',
+        )
+      }
+    })
+
+    it('allows optional title', () => {
+      const result = updateCardSchema.safeParse({
+        id: 'card-123',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('allows null description', () => {
+      const result = updateCardSchema.safeParse({
+        id: 'card-123',
+        description: null,
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('allows position update', () => {
+      const result = updateCardSchema.safeParse({
+        id: 'card-123',
+        position: 5,
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects negative position', () => {
+      const result = updateCardSchema.safeParse({
+        id: 'card-123',
+        position: -1,
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('allows null dueDate', () => {
+      const result = updateCardSchema.safeParse({
+        id: 'card-123',
+        dueDate: null,
+      })
+      expect(result.success).toBe(true)
+    })
+  })
+
+  describe('deleteCardSchema', () => {
+    it('validates correct delete data', () => {
+      const result = deleteCardSchema.safeParse({
+        id: 'card-123',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects empty id', () => {
+      const result = deleteCardSchema.safeParse({
+        id: '',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe(
+          'El ID de tarjeta es obligatorio',
+        )
+      }
+    })
+  })
+
+  describe('moveCardSchema', () => {
+    it('validates correct move data', () => {
+      const result = moveCardSchema.safeParse({
+        cardId: 'card-123',
+        targetListId: 'list-456',
+        position: 0,
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects empty cardId', () => {
+      const result = moveCardSchema.safeParse({
+        cardId: '',
+        targetListId: 'list-456',
+        position: 0,
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe(
+          'El ID de tarjeta es obligatorio',
+        )
+      }
+    })
+
+    it('rejects empty targetListId', () => {
+      const result = moveCardSchema.safeParse({
+        cardId: 'card-123',
+        targetListId: '',
+        position: 0,
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe(
+          'El ID de lista de destino es obligatorio',
+        )
+      }
+    })
+
+    it('rejects negative position', () => {
+      const result = moveCardSchema.safeParse({
+        cardId: 'card-123',
+        targetListId: 'list-456',
+        position: -1,
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe(
+          'La posición debe ser un número no negativo',
+        )
+      }
+    })
+
+    it('rejects non-integer position', () => {
+      const result = moveCardSchema.safeParse({
+        cardId: 'card-123',
+        targetListId: 'list-456',
+        position: 1.5,
+      })
+      expect(result.success).toBe(false)
+    })
+  })
+})

--- a/__tests__/lib/errors.test.ts
+++ b/__tests__/lib/errors.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { AppError, getErrorMessage, logError } from '@/lib/errors'
+
+describe('Errors', () => {
+  describe('AppError', () => {
+    it('creates an error with code and message', () => {
+      const error = new AppError('AUTH_INVALID_CREDENTIALS', 'Invalid login')
+      expect(error.code).toBe('AUTH_INVALID_CREDENTIALS')
+      expect(error.message).toBe('Invalid login')
+      expect(error.name).toBe('AppError')
+    })
+
+    it('stores original error', () => {
+      const originalError = new Error('Original')
+      const error = new AppError('INTERNAL_ERROR', 'Wrapped', originalError)
+      expect(error.originalError).toBe(originalError)
+    })
+
+    it('extends Error', () => {
+      const error = new AppError('NOT_FOUND', 'Not found')
+      expect(error).toBeInstanceOf(Error)
+      expect(error).toBeInstanceOf(AppError)
+    })
+
+    it('has correct error codes', () => {
+      const codes = [
+        'AUTH_INVALID_CREDENTIALS',
+        'AUTH_DUPLICATE_EMAIL',
+        'AUTH_UNKNOWN_ERROR',
+        'DB_CONNECTION_ERROR',
+        'VALIDATION_ERROR',
+        'UNAUTHORIZED',
+        'FORBIDDEN',
+        'NOT_FOUND',
+        'INTERNAL_ERROR',
+      ] as const
+
+      for (const code of codes) {
+        const error = new AppError(code, 'Test message')
+        expect(error.code).toBe(code)
+      }
+    })
+  })
+
+  describe('logError', () => {
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('logs error with context', () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const error = new Error('Test error')
+
+      logError(error, 'testFunction')
+
+      expect(consoleSpy).toHaveBeenCalledWith('[testFunction]', error)
+    })
+
+    it('logs non-Error objects', () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      logError('string error', 'context')
+
+      expect(consoleSpy).toHaveBeenCalledWith('[context]', 'string error')
+    })
+
+    it('logs AppError', () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const error = new AppError('UNAUTHORIZED', 'Access denied')
+
+      logError(error, 'authCheck')
+
+      expect(consoleSpy).toHaveBeenCalledWith('[authCheck]', error)
+    })
+  })
+
+  describe('getErrorMessage', () => {
+    it('returns message from AppError', () => {
+      const error = new AppError('FORBIDDEN', 'You cannot do this')
+      expect(getErrorMessage(error)).toBe('You cannot do this')
+    })
+
+    it('returns message from standard Error', () => {
+      const error = new Error('Standard error message')
+      expect(getErrorMessage(error)).toBe('Standard error message')
+    })
+
+    it('returns default message for non-Error objects', () => {
+      expect(getErrorMessage('string')).toBe('Ha ocurrido un error inesperado')
+      expect(getErrorMessage(null)).toBe('Ha ocurrido un error inesperado')
+      expect(getErrorMessage(undefined)).toBe('Ha ocurrido un error inesperado')
+      expect(getErrorMessage(123)).toBe('Ha ocurrido un error inesperado')
+      expect(getErrorMessage({})).toBe('Ha ocurrido un error inesperado')
+    })
+  })
+})

--- a/__tests__/lib/label/actions.test.ts
+++ b/__tests__/lib/label/actions.test.ts
@@ -1,0 +1,385 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Use vi.hoisted to define mock functions before they're used in vi.mock
+const {
+  mockQuery,
+  mockInsert,
+  mockUpdate,
+  mockDelete,
+  mockTransaction,
+  mockGetCurrentUser,
+} = vi.hoisted(() => ({
+  mockQuery: {
+    label: {
+      findFirst: vi.fn(),
+    },
+    board: {
+      findFirst: vi.fn(),
+    },
+    card: {
+      findFirst: vi.fn(),
+    },
+    cardLabel: {
+      findFirst: vi.fn(),
+    },
+  },
+  mockInsert: vi.fn(),
+  mockUpdate: vi.fn(),
+  mockDelete: vi.fn(),
+  mockTransaction: vi.fn(),
+  mockGetCurrentUser: vi.fn(),
+}))
+
+// Mock the database
+vi.mock('@/db', () => ({
+  db: {
+    query: mockQuery,
+    insert: mockInsert,
+    update: mockUpdate,
+    delete: mockDelete,
+    transaction: mockTransaction,
+  },
+}))
+
+// Mock auth
+vi.mock('@/lib/auth/get-user', () => ({
+  getCurrentUser: mockGetCurrentUser,
+}))
+
+// Mock errors
+vi.mock('@/lib/errors', () => ({
+  logError: vi.fn(),
+}))
+
+// Import after mocking
+import {
+  assignLabelToCard,
+  createLabel,
+  deleteLabel,
+  removeLabelFromCard,
+  updateLabel,
+} from '@/lib/label/actions'
+
+describe('Label Actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('createLabel', () => {
+    it('returns error when user is not authenticated', async () => {
+      mockGetCurrentUser.mockResolvedValue(null)
+
+      const result = await createLabel({
+        boardId: 'board-123',
+        color: '#FF0000',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('Debes iniciar sesión para crear una etiqueta')
+    })
+
+    it('returns error for invalid data - empty boardId', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+
+      const result = await createLabel({
+        boardId: '',
+        color: '#FF0000',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('El ID del tablero es obligatorio')
+    })
+
+    it('returns error for invalid color format', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+
+      const result = await createLabel({
+        boardId: 'board-123',
+        color: 'invalid',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('Formato de color hex inválido (#RRGGBB)')
+    })
+
+    it('returns error when board not found', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+      mockQuery.board.findFirst.mockResolvedValue(null)
+
+      const result = await createLabel({
+        boardId: 'board-123',
+        color: '#FF0000',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('Tablero no encontrado')
+    })
+
+    it('returns error when user is not board owner', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+      mockQuery.board.findFirst.mockResolvedValue({
+        id: 'board-123',
+        ownerId: 'other-user',
+      })
+
+      const result = await createLabel({
+        boardId: 'board-123',
+        color: '#FF0000',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe(
+        'Solo el propietario del tablero puede crear etiquetas',
+      )
+    })
+
+    it('creates label successfully', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+      mockQuery.board.findFirst.mockResolvedValue({
+        id: 'board-123',
+        ownerId: 'user-123',
+      })
+
+      const mockLabel = { id: 'label-123', color: '#FF0000', name: 'Bug' }
+      mockInsert.mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([mockLabel]),
+        }),
+      })
+
+      const result = await createLabel({
+        boardId: 'board-123',
+        color: '#FF0000',
+        name: 'Bug',
+      })
+
+      expect(result.success).toBe(true)
+      expect(result.data?.color).toBe('#FF0000')
+    })
+  })
+
+  describe('updateLabel', () => {
+    it('returns error when user is not authenticated', async () => {
+      mockGetCurrentUser.mockResolvedValue(null)
+
+      const result = await updateLabel({
+        id: 'label-123',
+        name: 'Updated',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe(
+        'Debes iniciar sesión para actualizar una etiqueta',
+      )
+    })
+
+    it('returns error for invalid data', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+
+      const result = await updateLabel({
+        id: '',
+        name: 'Updated',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('El ID de la etiqueta es obligatorio')
+    })
+
+    it('returns error when label not found', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+      mockQuery.label.findFirst.mockResolvedValue(null)
+
+      const result = await updateLabel({
+        id: 'label-123',
+        name: 'Updated',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('Etiqueta no encontrada')
+    })
+
+    it('returns error when user is not board owner', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+      mockQuery.label.findFirst.mockResolvedValue({
+        id: 'label-123',
+        board: { ownerId: 'other-user' },
+      })
+
+      const result = await updateLabel({
+        id: 'label-123',
+        name: 'Updated',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe(
+        'Solo el propietario del tablero puede editar etiquetas',
+      )
+    })
+
+    it('updates label successfully', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+      mockQuery.label.findFirst.mockResolvedValue({
+        id: 'label-123',
+        boardId: 'board-123',
+        board: { ownerId: 'user-123' },
+      })
+
+      const mockLabel = { id: 'label-123', name: 'Updated', color: '#FF0000' }
+      mockUpdate.mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([mockLabel]),
+          }),
+        }),
+      })
+
+      const result = await updateLabel({
+        id: 'label-123',
+        name: 'Updated',
+      })
+
+      expect(result.success).toBe(true)
+      expect(result.data?.name).toBe('Updated')
+    })
+  })
+
+  describe('deleteLabel', () => {
+    it('returns error when user is not authenticated', async () => {
+      mockGetCurrentUser.mockResolvedValue(null)
+
+      const result = await deleteLabel({
+        id: 'label-123',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe(
+        'Debes iniciar sesión para eliminar una etiqueta',
+      )
+    })
+
+    it('returns error for invalid data', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+
+      const result = await deleteLabel({
+        id: '',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('El ID de la etiqueta es obligatorio')
+    })
+
+    it('returns error when label not found', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+      mockQuery.label.findFirst.mockResolvedValue(null)
+
+      const result = await deleteLabel({
+        id: 'label-123',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('Etiqueta no encontrada')
+    })
+
+    it('returns error when user is not board owner', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+      mockQuery.label.findFirst.mockResolvedValue({
+        id: 'label-123',
+        board: { ownerId: 'other-user' },
+      })
+
+      const result = await deleteLabel({
+        id: 'label-123',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe(
+        'Solo el propietario del tablero puede eliminar etiquetas',
+      )
+    })
+
+    it('deletes label successfully', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+      mockQuery.label.findFirst.mockResolvedValue({
+        id: 'label-123',
+        boardId: 'board-123',
+        board: { ownerId: 'user-123' },
+      })
+
+      mockDelete.mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      })
+
+      const result = await deleteLabel({
+        id: 'label-123',
+      })
+
+      expect(result.success).toBe(true)
+    })
+  })
+
+  describe('assignLabelToCard', () => {
+    it('returns error when user is not authenticated', async () => {
+      mockGetCurrentUser.mockResolvedValue(null)
+
+      const result = await assignLabelToCard({
+        cardId: 'card-123',
+        labelId: 'label-123',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe(
+        'Debes iniciar sesión para asignar una etiqueta',
+      )
+    })
+
+    it('returns error for invalid data - empty cardId', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+
+      const result = await assignLabelToCard({
+        cardId: '',
+        labelId: 'label-123',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('El ID de la tarjeta es obligatorio')
+    })
+
+    it('returns error for invalid data - empty labelId', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+
+      const result = await assignLabelToCard({
+        cardId: 'card-123',
+        labelId: '',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('El ID de la etiqueta es obligatorio')
+    })
+  })
+
+  describe('removeLabelFromCard', () => {
+    it('returns error when user is not authenticated', async () => {
+      mockGetCurrentUser.mockResolvedValue(null)
+
+      const result = await removeLabelFromCard({
+        cardId: 'card-123',
+        labelId: 'label-123',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('Debes iniciar sesión para quitar una etiqueta')
+    })
+
+    it('returns error for invalid data', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+
+      const result = await removeLabelFromCard({
+        cardId: '',
+        labelId: 'label-123',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('El ID de la tarjeta es obligatorio')
+    })
+  })
+})

--- a/__tests__/lib/label/schemas.test.ts
+++ b/__tests__/lib/label/schemas.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from 'vitest'
+import {
+  assignLabelToCardSchema,
+  createLabelSchema,
+  deleteLabelSchema,
+  updateLabelSchema,
+} from '@/lib/label/schemas'
+
+describe('Label Schemas', () => {
+  describe('createLabelSchema', () => {
+    it('validates correct label data', () => {
+      const result = createLabelSchema.safeParse({
+        boardId: 'board-123',
+        name: 'Bug',
+        color: '#FF0000',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('transforms color to uppercase', () => {
+      const result = createLabelSchema.safeParse({
+        boardId: 'board-123',
+        name: 'Bug',
+        color: '#ff0000',
+      })
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.color).toBe('#FF0000')
+      }
+    })
+
+    it('allows optional name', () => {
+      const result = createLabelSchema.safeParse({
+        boardId: 'board-123',
+        color: '#FF0000',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects empty boardId', () => {
+      const result = createLabelSchema.safeParse({
+        boardId: '',
+        color: '#FF0000',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe(
+          'El ID del tablero es obligatorio',
+        )
+      }
+    })
+
+    it('rejects name longer than 100 characters', () => {
+      const result = createLabelSchema.safeParse({
+        boardId: 'board-123',
+        name: 'A'.repeat(101),
+        color: '#FF0000',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe(
+          'El nombre debe tener menos de 100 caracteres',
+        )
+      }
+    })
+
+    it('rejects invalid hex color', () => {
+      const result = createLabelSchema.safeParse({
+        boardId: 'board-123',
+        color: 'not-a-color',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe(
+          'Formato de color hex inválido (#RRGGBB)',
+        )
+      }
+    })
+
+    it('rejects 3-digit hex color', () => {
+      const result = createLabelSchema.safeParse({
+        boardId: 'board-123',
+        color: '#FFF',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('accepts valid hex colors', () => {
+      const colors = ['#000000', '#FFFFFF', '#AbCdEf', '#123456']
+      for (const color of colors) {
+        const result = createLabelSchema.safeParse({
+          boardId: 'board-123',
+          color,
+        })
+        expect(result.success).toBe(true)
+      }
+    })
+  })
+
+  describe('updateLabelSchema', () => {
+    it('validates correct update data', () => {
+      const result = updateLabelSchema.safeParse({
+        id: 'label-123',
+        name: 'Updated Label',
+        color: '#00FF00',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects empty id', () => {
+      const result = updateLabelSchema.safeParse({
+        id: '',
+        name: 'Updated Label',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe(
+          'El ID de la etiqueta es obligatorio',
+        )
+      }
+    })
+
+    it('allows optional name and color', () => {
+      const result = updateLabelSchema.safeParse({
+        id: 'label-123',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('transforms color to uppercase', () => {
+      const result = updateLabelSchema.safeParse({
+        id: 'label-123',
+        color: '#abcdef',
+      })
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.color).toBe('#ABCDEF')
+      }
+    })
+  })
+
+  describe('deleteLabelSchema', () => {
+    it('validates correct delete data', () => {
+      const result = deleteLabelSchema.safeParse({
+        id: 'label-123',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects empty id', () => {
+      const result = deleteLabelSchema.safeParse({
+        id: '',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe(
+          'El ID de la etiqueta es obligatorio',
+        )
+      }
+    })
+  })
+
+  describe('assignLabelToCardSchema', () => {
+    it('validates correct assign data', () => {
+      const result = assignLabelToCardSchema.safeParse({
+        cardId: 'card-123',
+        labelId: 'label-456',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects empty cardId', () => {
+      const result = assignLabelToCardSchema.safeParse({
+        cardId: '',
+        labelId: 'label-456',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe(
+          'El ID de la tarjeta es obligatorio',
+        )
+      }
+    })
+
+    it('rejects empty labelId', () => {
+      const result = assignLabelToCardSchema.safeParse({
+        cardId: 'card-123',
+        labelId: '',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe(
+          'El ID de la etiqueta es obligatorio',
+        )
+      }
+    })
+  })
+})

--- a/__tests__/lib/list/actions.test.ts
+++ b/__tests__/lib/list/actions.test.ts
@@ -1,0 +1,326 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Use vi.hoisted to define mock functions before they're used in vi.mock
+const {
+  mockQuery,
+  mockInsert,
+  mockUpdate,
+  mockDelete,
+  mockSelect,
+  mockTransaction,
+  mockGetCurrentUser,
+} = vi.hoisted(() => ({
+  mockQuery: {
+    list: {
+      findFirst: vi.fn(),
+    },
+    board: {
+      findFirst: vi.fn(),
+    },
+  },
+  mockInsert: vi.fn(),
+  mockUpdate: vi.fn(),
+  mockDelete: vi.fn(),
+  mockSelect: vi.fn(),
+  mockTransaction: vi.fn(),
+  mockGetCurrentUser: vi.fn(),
+}))
+
+// Mock the database
+vi.mock('@/db', () => ({
+  db: {
+    query: mockQuery,
+    insert: mockInsert,
+    update: mockUpdate,
+    delete: mockDelete,
+    select: mockSelect,
+    transaction: mockTransaction,
+  },
+}))
+
+// Mock auth
+vi.mock('@/lib/auth/get-user', () => ({
+  getCurrentUser: mockGetCurrentUser,
+}))
+
+// Mock errors
+vi.mock('@/lib/errors', () => ({
+  logError: vi.fn(),
+}))
+
+// Import after mocking
+import { createList, deleteList, updateList } from '@/lib/list/actions'
+
+describe('List Actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('createList', () => {
+    it('returns error when user is not authenticated', async () => {
+      mockGetCurrentUser.mockResolvedValue(null)
+
+      const result = await createList({
+        title: 'My List',
+        boardId: 'board-123',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('Debes iniciar sesión para crear una lista')
+    })
+
+    it('returns error for invalid data - empty title', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+
+      const result = await createList({
+        title: '',
+        boardId: 'board-123',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('Title is required')
+    })
+
+    it('returns error for invalid data - empty boardId', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+
+      const result = await createList({
+        title: 'My List',
+        boardId: '',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('Board ID is required')
+    })
+
+    it('returns error when board not found', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+      mockQuery.board.findFirst.mockResolvedValue(null)
+
+      const result = await createList({
+        title: 'My List',
+        boardId: 'board-123',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('Tablero no encontrado')
+    })
+
+    it('returns error when user is not board owner', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+      mockQuery.board.findFirst.mockResolvedValue({
+        id: 'board-123',
+        ownerId: 'other-user',
+      })
+
+      const result = await createList({
+        title: 'My List',
+        boardId: 'board-123',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe(
+        'No tienes permiso para añadir listas a este tablero',
+      )
+    })
+
+    it('creates list successfully', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+      mockQuery.board.findFirst.mockResolvedValue({
+        id: 'board-123',
+        ownerId: 'user-123',
+      })
+
+      const mockList = { id: 'list-123', title: 'My List' }
+
+      mockTransaction.mockImplementation(async (callback) => {
+        const lockQueryMock = {
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              for: vi.fn().mockResolvedValue([{ id: 'board-123' }]),
+            }),
+          }),
+        }
+
+        const maxPosQueryMock = {
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ max: 0 }]),
+          }),
+        }
+
+        const tx = {
+          select: vi
+            .fn()
+            .mockReturnValueOnce(lockQueryMock)
+            .mockReturnValueOnce(maxPosQueryMock),
+          insert: vi.fn().mockReturnValue({
+            values: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([mockList]),
+            }),
+          }),
+        }
+        return callback(tx)
+      })
+
+      const result = await createList({
+        title: 'My List',
+        boardId: 'board-123',
+      })
+
+      expect(result.success).toBe(true)
+    })
+  })
+
+  describe('updateList', () => {
+    it('returns error when user is not authenticated', async () => {
+      mockGetCurrentUser.mockResolvedValue(null)
+
+      const result = await updateList({
+        id: 'list-123',
+        title: 'Updated',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe(
+        'Debes iniciar sesión para actualizar una lista',
+      )
+    })
+
+    it('returns error for invalid data', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+
+      const result = await updateList({
+        id: '',
+        title: 'Updated',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('List ID is required')
+    })
+
+    it('returns error when list not found', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+      mockQuery.list.findFirst.mockResolvedValue(null)
+
+      const result = await updateList({
+        id: 'list-123',
+        title: 'Updated',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('Lista no encontrada')
+    })
+
+    it('returns error when user is not board owner', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+      mockQuery.list.findFirst.mockResolvedValue({
+        id: 'list-123',
+        board: { ownerId: 'other-user' },
+      })
+
+      const result = await updateList({
+        id: 'list-123',
+        title: 'Updated',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('No tienes permiso para actualizar esta lista')
+    })
+
+    it('updates list successfully', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+      mockQuery.list.findFirst.mockResolvedValue({
+        id: 'list-123',
+        boardId: 'board-123',
+        board: { ownerId: 'user-123' },
+      })
+
+      const mockList = { id: 'list-123', title: 'Updated' }
+      mockUpdate.mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([mockList]),
+          }),
+        }),
+      })
+
+      const result = await updateList({
+        id: 'list-123',
+        title: 'Updated',
+      })
+
+      expect(result.success).toBe(true)
+      expect(result.data?.title).toBe('Updated')
+    })
+  })
+
+  describe('deleteList', () => {
+    it('returns error when user is not authenticated', async () => {
+      mockGetCurrentUser.mockResolvedValue(null)
+
+      const result = await deleteList({
+        id: 'list-123',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('Debes iniciar sesión para eliminar una lista')
+    })
+
+    it('returns error for invalid data', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+
+      const result = await deleteList({
+        id: '',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('List ID is required')
+    })
+
+    it('returns error when list not found', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+      mockQuery.list.findFirst.mockResolvedValue(null)
+
+      const result = await deleteList({
+        id: 'list-123',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('Lista no encontrada')
+    })
+
+    it('returns error when user is not board owner', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+      mockQuery.list.findFirst.mockResolvedValue({
+        id: 'list-123',
+        board: { ownerId: 'other-user' },
+      })
+
+      const result = await deleteList({
+        id: 'list-123',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('No tienes permiso para eliminar esta lista')
+    })
+
+    it('deletes list successfully', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user-123' })
+      mockQuery.list.findFirst.mockResolvedValue({
+        id: 'list-123',
+        boardId: 'board-123',
+        board: { ownerId: 'user-123' },
+      })
+
+      mockDelete.mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      })
+
+      const result = await deleteList({
+        id: 'list-123',
+      })
+
+      expect(result.success).toBe(true)
+    })
+  })
+})

--- a/__tests__/lib/list/schemas.test.ts
+++ b/__tests__/lib/list/schemas.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createListSchema,
+  deleteListSchema,
+  updateListSchema,
+} from '@/lib/list/schemas'
+
+describe('List Schemas', () => {
+  describe('createListSchema', () => {
+    it('validates correct list data', () => {
+      const result = createListSchema.safeParse({
+        title: 'My List',
+        boardId: 'board-123',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects empty title', () => {
+      const result = createListSchema.safeParse({
+        title: '',
+        boardId: 'board-123',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe('Title is required')
+      }
+    })
+
+    it('rejects title longer than 255 characters', () => {
+      const result = createListSchema.safeParse({
+        title: 'A'.repeat(256),
+        boardId: 'board-123',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe(
+          'Title must be less than 255 characters',
+        )
+      }
+    })
+
+    it('rejects empty boardId', () => {
+      const result = createListSchema.safeParse({
+        title: 'My List',
+        boardId: '',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe('Board ID is required')
+      }
+    })
+  })
+
+  describe('updateListSchema', () => {
+    it('validates correct update data', () => {
+      const result = updateListSchema.safeParse({
+        id: 'list-123',
+        title: 'Updated Title',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects empty id', () => {
+      const result = updateListSchema.safeParse({
+        id: '',
+        title: 'Updated Title',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe('List ID is required')
+      }
+    })
+
+    it('allows optional title', () => {
+      const result = updateListSchema.safeParse({
+        id: 'list-123',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('allows position update', () => {
+      const result = updateListSchema.safeParse({
+        id: 'list-123',
+        position: 3,
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects negative position', () => {
+      const result = updateListSchema.safeParse({
+        id: 'list-123',
+        position: -1,
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects non-integer position', () => {
+      const result = updateListSchema.safeParse({
+        id: 'list-123',
+        position: 1.5,
+      })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('deleteListSchema', () => {
+    it('validates correct delete data', () => {
+      const result = deleteListSchema.safeParse({
+        id: 'list-123',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects empty id', () => {
+      const result = deleteListSchema.safeParse({
+        id: '',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe('List ID is required')
+      }
+    })
+  })
+})

--- a/__tests__/lib/utils.test.ts
+++ b/__tests__/lib/utils.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import { cn } from '@/lib/utils'
+
+describe('Utils', () => {
+  describe('cn', () => {
+    it('merges class names', () => {
+      const result = cn('class1', 'class2')
+      expect(result).toBe('class1 class2')
+    })
+
+    it('handles undefined values', () => {
+      const result = cn('class1', undefined, 'class2')
+      expect(result).toBe('class1 class2')
+    })
+
+    it('handles false values', () => {
+      const result = cn('class1', false && 'class2', 'class3')
+      expect(result).toBe('class1 class3')
+    })
+
+    it('handles conditional classes', () => {
+      const isActive = true
+      const result = cn('base', isActive && 'active')
+      expect(result).toBe('base active')
+    })
+
+    it('handles conditional false classes', () => {
+      const isActive = false
+      const result = cn('base', isActive && 'active')
+      expect(result).toBe('base')
+    })
+
+    it('merges Tailwind classes correctly', () => {
+      const result = cn('px-4 py-2', 'px-6')
+      expect(result).toBe('py-2 px-6')
+    })
+
+    it('resolves Tailwind conflicts with last value winning', () => {
+      const result = cn('text-red-500', 'text-blue-500')
+      expect(result).toBe('text-blue-500')
+    })
+
+    it('handles empty input', () => {
+      const result = cn()
+      expect(result).toBe('')
+    })
+
+    it('handles null values', () => {
+      const result = cn('class1', null, 'class2')
+      expect(result).toBe('class1 class2')
+    })
+
+    it('handles array of classes', () => {
+      const result = cn(['class1', 'class2'])
+      expect(result).toBe('class1 class2')
+    })
+
+    it('handles object syntax', () => {
+      const result = cn({
+        class1: true,
+        class2: false,
+        class3: true,
+      })
+      expect(result).toBe('class1 class3')
+    })
+
+    it('handles mixed syntax', () => {
+      const result = cn('base', ['array1', 'array2'], { object: true })
+      expect(result).toBe('base array1 array2 object')
+    })
+  })
+})

--- a/__tests__/mocks/auth.ts
+++ b/__tests__/mocks/auth.ts
@@ -1,0 +1,36 @@
+import { vi } from 'vitest'
+
+/**
+ * Mock user for authenticated tests
+ */
+export const mockUser = {
+  id: 'user-123',
+  email: 'test@example.com',
+  name: 'Test User',
+}
+
+/**
+ * Mock getCurrentUser function
+ */
+export const mockGetCurrentUser = vi.fn()
+
+/**
+ * Setup auth mock to return authenticated user
+ */
+export function setupAuthenticatedUser() {
+  mockGetCurrentUser.mockResolvedValue(mockUser)
+}
+
+/**
+ * Setup auth mock to return no user (unauthenticated)
+ */
+export function setupUnauthenticatedUser() {
+  mockGetCurrentUser.mockResolvedValue(null)
+}
+
+/**
+ * Mock module for @/lib/auth/get-user
+ */
+vi.mock('@/lib/auth/get-user', () => ({
+  getCurrentUser: mockGetCurrentUser,
+}))

--- a/__tests__/mocks/db.ts
+++ b/__tests__/mocks/db.ts
@@ -1,0 +1,80 @@
+import { vi } from 'vitest'
+
+/**
+ * Mock database for testing server actions.
+ * Provides mocked query and mutation methods.
+ */
+export const mockDb = {
+  query: {
+    board: {
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+    },
+    list: {
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+    },
+    card: {
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+    },
+    label: {
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+    },
+    cardLabel: {
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+    },
+  },
+  insert: vi.fn(() => ({
+    values: vi.fn(() => ({
+      returning: vi.fn(() => []),
+    })),
+  })),
+  update: vi.fn(() => ({
+    set: vi.fn(() => ({
+      where: vi.fn(() => ({
+        returning: vi.fn(() => []),
+      })),
+    })),
+  })),
+  delete: vi.fn(() => ({
+    where: vi.fn(() => Promise.resolve()),
+  })),
+  select: vi.fn(() => ({
+    from: vi.fn(() => ({
+      where: vi.fn(() => ({
+        for: vi.fn(() => []),
+      })),
+    })),
+  })),
+  transaction: vi.fn((callback) => callback(mockDb)),
+}
+
+/**
+ * Mock function to setup db mock in tests
+ */
+export function setupDbMock() {
+  vi.mock('@/db', () => ({
+    db: mockDb,
+  }))
+}
+
+/**
+ * Reset all mocks
+ */
+export function resetDbMocks() {
+  Object.values(mockDb.query).forEach((entity) => {
+    Object.values(entity).forEach((fn) => {
+      if (typeof fn === 'function' && 'mockReset' in fn) {
+        ;(fn as ReturnType<typeof vi.fn>).mockReset()
+      }
+    })
+  })
+  mockDb.insert.mockClear()
+  mockDb.update.mockClear()
+  mockDb.delete.mockClear()
+  mockDb.select.mockClear()
+  mockDb.transaction.mockClear()
+}

--- a/__tests__/store/board-store.test.ts
+++ b/__tests__/store/board-store.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { useBoardStore } from '@/store/board-store'
+
+describe('Board Store', () => {
+  beforeEach(() => {
+    // Reset store to initial state before each test
+    useBoardStore.setState({
+      activeCard: null,
+      isCardModalOpen: false,
+    })
+  })
+
+  afterEach(() => {
+    // Clean up after each test
+    useBoardStore.setState({
+      activeCard: null,
+      isCardModalOpen: false,
+    })
+  })
+
+  describe('activeCard', () => {
+    it('has null as initial value', () => {
+      expect(useBoardStore.getState().activeCard).toBeNull()
+    })
+
+    it('sets active card', () => {
+      const { setActiveCard } = useBoardStore.getState()
+      setActiveCard('card-123')
+      expect(useBoardStore.getState().activeCard).toBe('card-123')
+    })
+
+    it('clears active card with null', () => {
+      const { setActiveCard } = useBoardStore.getState()
+      setActiveCard('card-123')
+      setActiveCard(null)
+      expect(useBoardStore.getState().activeCard).toBeNull()
+    })
+
+    it('changes active card', () => {
+      const { setActiveCard } = useBoardStore.getState()
+      setActiveCard('card-123')
+      setActiveCard('card-456')
+      expect(useBoardStore.getState().activeCard).toBe('card-456')
+    })
+  })
+
+  describe('isCardModalOpen', () => {
+    it('has false as initial value', () => {
+      expect(useBoardStore.getState().isCardModalOpen).toBe(false)
+    })
+
+    it('opens card modal', () => {
+      const { openCardModal } = useBoardStore.getState()
+      openCardModal()
+      expect(useBoardStore.getState().isCardModalOpen).toBe(true)
+    })
+
+    it('closes card modal', () => {
+      const { openCardModal, closeCardModal } = useBoardStore.getState()
+      openCardModal()
+      closeCardModal()
+      expect(useBoardStore.getState().isCardModalOpen).toBe(false)
+    })
+
+    it('stays open when called multiple times', () => {
+      const { openCardModal } = useBoardStore.getState()
+      openCardModal()
+      openCardModal()
+      expect(useBoardStore.getState().isCardModalOpen).toBe(true)
+    })
+  })
+
+  describe('combined usage', () => {
+    it('sets active card and opens modal together', () => {
+      const { setActiveCard, openCardModal } = useBoardStore.getState()
+      setActiveCard('card-123')
+      openCardModal()
+
+      const state = useBoardStore.getState()
+      expect(state.activeCard).toBe('card-123')
+      expect(state.isCardModalOpen).toBe(true)
+    })
+
+    it('clears active card and closes modal together', () => {
+      const { setActiveCard, openCardModal, closeCardModal } =
+        useBoardStore.getState()
+
+      // Set up
+      setActiveCard('card-123')
+      openCardModal()
+
+      // Tear down
+      setActiveCard(null)
+      closeCardModal()
+
+      const state = useBoardStore.getState()
+      expect(state.activeCard).toBeNull()
+      expect(state.isCardModalOpen).toBe(false)
+    })
+  })
+})

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "build": "next build",
     "start": "next start",
     "lint": "biome check",
-    "format": "biome format --write --files-ignore-unknown=true"
+    "format": "biome format --write --files-ignore-unknown=true",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@base-ui-components/react": "1.0.0-rc.0",
@@ -49,14 +52,22 @@
   "devDependencies": {
     "@biomejs/biome": "2.2.0",
     "@tailwindcss/postcss": "^4",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.1",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^20",
     "@types/pg": "^8.16.0",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@vitejs/plugin-react": "^5.1.2",
+    "@vitest/coverage-v8": "^4.0.16",
     "drizzle-kit": "^0.31.8",
+    "jsdom": "^24.1.3",
     "tailwindcss": "^4",
     "tsx": "^4.21.0",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vite-tsconfig-paths": "^6.0.3",
+    "vitest": "^4.0.16"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,7 +55,7 @@ importers:
         version: 1.2.2(@types/react@19.2.7)(react@19.2.1)
       better-auth:
         specifier: ^1.4.6
-        version: 1.4.6(next@16.0.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        version: 1.4.6(next@16.0.8(@babel/core@7.28.5)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -82,7 +82,7 @@ importers:
         version: 12.23.26(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       next:
         specifier: 16.0.8
-        version: 16.0.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        version: 16.0.8(@babel/core@7.28.5)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -120,6 +120,15 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.1.17
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
+      '@testing-library/react':
+        specifier: ^16.3.1
+        version: 16.3.1(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^20
         version: 20.19.26
@@ -132,9 +141,18 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.2.3(@types/react@19.2.7)
+      '@vitejs/plugin-react':
+        specifier: ^5.1.2
+        version: 5.1.2(vite@7.3.0(@types/node@20.19.26)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+      '@vitest/coverage-v8':
+        specifier: ^4.0.16
+        version: 4.0.16(vitest@4.0.16(@types/node@20.19.26)(jiti@2.6.1)(jsdom@24.1.3)(lightningcss@1.30.2)(tsx@4.21.0))
       drizzle-kit:
         specifier: ^0.31.8
         version: 0.31.8
+      jsdom:
+        specifier: ^24.1.3
+        version: 24.1.3
       tailwindcss:
         specifier: ^4
         version: 4.1.17
@@ -147,6 +165,12 @@ importers:
       typescript:
         specifier: ^5
         version: 5.9.3
+      vite-tsconfig-paths:
+        specifier: ^6.0.3
+        version: 6.0.3(typescript@5.9.3)(vite@7.3.0(@types/node@20.19.26)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+      vitest:
+        specifier: ^4.0.16
+        version: 4.0.16(@types/node@20.19.26)(jiti@2.6.1)(jsdom@24.1.3)(lightningcss@1.30.2)(tsx@4.21.0)
 
 packages:
 
@@ -154,8 +178,94 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@babel/code-frame@7.27.1':
+    resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.28.5':
+    resolution: {integrity: sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.28.5':
+    resolution: {integrity: sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.28.5':
+    resolution: {integrity: sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.27.2':
+    resolution: {integrity: sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.27.1':
+    resolution: {integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.28.3':
+    resolution: {integrity: sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.27.1':
+    resolution: {integrity: sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.28.4':
+    resolution: {integrity: sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.28.5':
+    resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1':
+    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1':
+    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/runtime@7.28.4':
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/template@7.27.2':
+    resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.28.5':
+    resolution: {integrity: sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.28.5':
+    resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
 
   '@base-ui-components/react@1.0.0-rc.0':
@@ -180,6 +290,10 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@better-auth/core@1.4.6':
     resolution: {integrity: sha512-cYjscr4wU5ZJPhk86JuUkecJT+LSYCFmUzYaitiLkizl+wCr1qdPFSEoAnRVZVTUEEoKpeS2XW69voBJ1NoB3g==}
@@ -254,6 +368,34 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
@@ -1392,6 +1534,119 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@rolldown/pluginutils@1.0.0-beta.53':
+    resolution: {integrity: sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==}
+
+  '@rollup/rollup-android-arm-eabi@4.54.0':
+    resolution: {integrity: sha512-OywsdRHrFvCdvsewAInDKCNyR3laPA2mc9bRYJ6LBp5IyvF3fvXbbNR0bSzHlZVFtn6E0xw2oZlyjg4rKCVcng==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.54.0':
+    resolution: {integrity: sha512-Skx39Uv+u7H224Af+bDgNinitlmHyQX1K/atIA32JP3JQw6hVODX5tkbi2zof/E69M1qH2UoN3Xdxgs90mmNYw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.54.0':
+    resolution: {integrity: sha512-k43D4qta/+6Fq+nCDhhv9yP2HdeKeP56QrUUTW7E6PhZP1US6NDqpJj4MY0jBHlJivVJD5P8NxrjuobZBJTCRw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.54.0':
+    resolution: {integrity: sha512-cOo7biqwkpawslEfox5Vs8/qj83M/aZCSSNIWpVzfU2CYHa2G3P1UN5WF01RdTHSgCkri7XOlTdtk17BezlV3A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.54.0':
+    resolution: {integrity: sha512-miSvuFkmvFbgJ1BevMa4CPCFt5MPGw094knM64W9I0giUIMMmRYcGW/JWZDriaw/k1kOBtsWh1z6nIFV1vPNtA==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.54.0':
+    resolution: {integrity: sha512-KGXIs55+b/ZfZsq9aR026tmr/+7tq6VG6MsnrvF4H8VhwflTIuYh+LFUlIsRdQSgrgmtM3fVATzEAj4hBQlaqQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.54.0':
+    resolution: {integrity: sha512-EHMUcDwhtdRGlXZsGSIuXSYwD5kOT9NVnx9sqzYiwAc91wfYOE1g1djOEDseZJKKqtHAHGwnGPQu3kytmfaXLQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.54.0':
+    resolution: {integrity: sha512-+pBrqEjaakN2ySv5RVrj/qLytYhPKEUwk+e3SFU5jTLHIcAtqh2rLrd/OkbNuHJpsBgxsD8ccJt5ga/SeG0JmA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.54.0':
+    resolution: {integrity: sha512-NSqc7rE9wuUaRBsBp5ckQ5CVz5aIRKCwsoa6WMF7G01sX3/qHUw/z4pv+D+ahL1EIKy6Enpcnz1RY8pf7bjwng==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.54.0':
+    resolution: {integrity: sha512-gr5vDbg3Bakga5kbdpqx81m2n9IX8M6gIMlQQIXiLTNeQW6CucvuInJ91EuCJ/JYvc+rcLLsDFcfAD1K7fMofg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.54.0':
+    resolution: {integrity: sha512-gsrtB1NA3ZYj2vq0Rzkylo9ylCtW/PhpLEivlgWe0bpgtX5+9j9EZa0wtZiCjgu6zmSeZWyI/e2YRX1URozpIw==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.54.0':
+    resolution: {integrity: sha512-y3qNOfTBStmFNq+t4s7Tmc9hW2ENtPg8FeUD/VShI7rKxNW7O4fFeaYbMsd3tpFlIg1Q8IapFgy7Q9i2BqeBvA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.54.0':
+    resolution: {integrity: sha512-89sepv7h2lIVPsFma8iwmccN7Yjjtgz0Rj/Ou6fEqg3HDhpCa+Et+YSufy27i6b0Wav69Qv4WBNl3Rs6pwhebQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.54.0':
+    resolution: {integrity: sha512-ZcU77ieh0M2Q8Ur7D5X7KvK+UxbXeDHwiOt/CPSBTI1fBmeDMivW0dPkdqkT4rOgDjrDDBUed9x4EgraIKoR2A==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.54.0':
+    resolution: {integrity: sha512-2AdWy5RdDF5+4YfG/YesGDDtbyJlC9LHmL6rZw6FurBJ5n4vFGupsOBGfwMRjBYH7qRQowT8D/U4LoSvVwOhSQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.54.0':
+    resolution: {integrity: sha512-WGt5J8Ij/rvyqpFexxk3ffKqqbLf9AqrTBbWDk7ApGUzaIs6V+s2s84kAxklFwmMF/vBNGrVdYgbblCOFFezMQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.54.0':
+    resolution: {integrity: sha512-JzQmb38ATzHjxlPHuTH6tE7ojnMKM2kYNzt44LO/jJi8BpceEC8QuXYA908n8r3CNuG/B3BV8VR3Hi1rYtmPiw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openharmony-arm64@4.54.0':
+    resolution: {integrity: sha512-huT3fd0iC7jigGh7n3q/+lfPcXxBi+om/Rs3yiFxjvSxbSB6aohDFXbWvlspaqjeOh+hx7DDHS+5Es5qRkWkZg==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.54.0':
+    resolution: {integrity: sha512-c2V0W1bsKIKfbLMBu/WGBz6Yci8nJ/ZJdheE0EwB73N3MvHYKiKGs3mVilX4Gs70eGeDaMqEob25Tw2Gb9Nqyw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.54.0':
+    resolution: {integrity: sha512-woEHgqQqDCkAzrDhvDipnSirm5vxUXtSKDYTVpZG3nUdW/VVB5VdCYA2iReSj/u3yCZzXID4kuKG7OynPnB3WQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.54.0':
+    resolution: {integrity: sha512-dzAc53LOuFvHwbCEOS0rPbXp6SIhAf2txMP5p6mGyOXXw5mWY8NGGbPMPrs4P1WItkfApDathBj/NzMLUZ9rtQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.54.0':
+    resolution: {integrity: sha512-hYT5d3YNdSh3mbCU1gwQyPgQd3T2ne0A3KG8KSBdav5TiBg6eInVmV+TeR5uHufiIgSFg0XsOWGW5/RhNcSvPg==}
+    cpu: [x64]
+    os: [win32]
+
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
@@ -1489,6 +1744,55 @@ packages:
   '@tailwindcss/postcss@4.1.17':
     resolution: {integrity: sha512-+nKl9N9mN5uJ+M7dBOOCzINw94MPstNR/GtIhz1fpZysxL/4a+No64jCBD6CPN+bIHWFx3KWuu8XJRrj/572Dw==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.1':
+    resolution: {integrity: sha512-gr4KtAWqIOQoucWYD/f6ki+j5chXfcPc74Col/6poTyqTmn7zRmodWahWRCp8tYd+GMqBonw6hstNzqjbs6gjw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
   '@types/node@20.19.26':
     resolution: {integrity: sha512-0l6cjgF0XnihUpndDhk+nyD3exio3iKaYROSgvh/qSevPXax3L8p5DBRFjbvalnwatGgHEQn2R88y2fA3g4irg==}
 
@@ -1503,9 +1807,82 @@ packages:
   '@types/react@19.2.7':
     resolution: {integrity: sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==}
 
+  '@vitejs/plugin-react@5.1.2':
+    resolution: {integrity: sha512-EcA07pHJouywpzsoTUqNh5NwGayl2PPVEJKUSinGGSxFGYn+shYbqMGBg6FXDqgXum9Ou/ecb+411ssw8HImJQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  '@vitest/coverage-v8@4.0.16':
+    resolution: {integrity: sha512-2rNdjEIsPRzsdu6/9Eq0AYAzYdpP6Bx9cje9tL3FE5XzXRQF1fNU9pe/1yE8fCrS0HD+fBtt6gLPh6LI57tX7A==}
+    peerDependencies:
+      '@vitest/browser': 4.0.16
+      vitest: 4.0.16
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@4.0.16':
+    resolution: {integrity: sha512-eshqULT2It7McaJkQGLkPjPjNph+uevROGuIMJdG3V+0BSR2w9u6J9Lwu+E8cK5TETlfou8GRijhafIMhXsimA==}
+
+  '@vitest/mocker@4.0.16':
+    resolution: {integrity: sha512-yb6k4AZxJTB+q9ycAvsoxGn+j/po0UaPgajllBgt1PzoMAAmJGYFdDk0uCcRcxb3BrME34I6u8gHZTQlkqSZpg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.0.16':
+    resolution: {integrity: sha512-eNCYNsSty9xJKi/UdVD8Ou16alu7AYiS2fCPRs0b1OdhJiV89buAXQLpTbe+X8V9L6qrs9CqyvU7OaAopJYPsA==}
+
+  '@vitest/runner@4.0.16':
+    resolution: {integrity: sha512-VWEDm5Wv9xEo80ctjORcTQRJ539EGPB3Pb9ApvVRAY1U/WkHXmmYISqU5E79uCwcW7xYUV38gwZD+RV755fu3Q==}
+
+  '@vitest/snapshot@4.0.16':
+    resolution: {integrity: sha512-sf6NcrYhYBsSYefxnry+DR8n3UV4xWZwWxYbCJUt2YdvtqzSPR7VfGrY0zsv090DAbjFZsi7ZaMi1KnSRyK1XA==}
+
+  '@vitest/spy@4.0.16':
+    resolution: {integrity: sha512-4jIOWjKP0ZUaEmJm00E0cOBLU+5WE0BpeNr3XN6TEF05ltro6NJqHWxXD0kA8/Zc8Nh23AT8WQxwNG+WeROupw==}
+
+  '@vitest/utils@4.0.16':
+    resolution: {integrity: sha512-h8z9yYhV3e1LEfaQ3zdypIrnAg/9hguReGZoS7Gl0aBG5xgA410zBqECqmaF/+RkTggRsfnzc1XaAHA6bmUufA==}
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@0.3.9:
+    resolution: {integrity: sha512-dSC6tJeOJxbZrPzPbv5mMd6CMiQ1ugaVXXPRad2fXUSsy1kstFn9XQWemV9VW7Y7kpxgQ/4WMoZfwdH8XSU48w==}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  baseline-browser-mapping@2.9.11:
+    resolution: {integrity: sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ==}
+    hasBin: true
 
   better-auth@1.4.6:
     resolution: {integrity: sha512-5wEBzjolrQA26b4uT6FVVYICsE3SmE/MzrZtl8cb2a3TJtswpP8v3OVV5yTso+ef9z85swgZk0/qBzcULFWVtA==}
@@ -1547,11 +1924,24 @@ packages:
       zod:
         optional: true
 
+  browserslist@4.28.1:
+    resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
   caniuse-lite@1.0.30001760:
     resolution: {integrity: sha512-7AAMPcueWELt1p3mi13HR/LHH0TJLT11cnwDJEs3xA4+CK/PLKeO9Kl1oru24htkyUKtkGCvAx4ohB0Ttry8Dw==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
@@ -1563,8 +1953,23 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
 
   date-fns-jalali@4.1.0-0:
     resolution: {integrity: sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==}
@@ -1581,8 +1986,19 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -1590,6 +2006,9 @@ packages:
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dotenv@17.2.3:
     resolution: {integrity: sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==}
@@ -1691,9 +2110,39 @@ packages:
       sqlite3:
         optional: true
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  electron-to-chromium@1.5.267:
+    resolution: {integrity: sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==}
+
   enhanced-resolve@5.18.3:
     resolution: {integrity: sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==}
     engines: {node: '>=10.13.0'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
 
   esbuild-register@3.6.0:
     resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
@@ -1715,6 +2164,30 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
   framer-motion@12.23.26:
     resolution: {integrity: sha512-cPcIhgR42xBn1Uj+PzOyheMtZ73H927+uWPDVhUMqxy8UHt6Okavb6xIz9J/phFUHUj0OncR6UvMfJTXoc/LKA==}
     peerDependencies:
@@ -1734,15 +2207,91 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
   get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
 
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
   get-tsconfig@4.13.0:
     resolution: {integrity: sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==}
 
+  globrex@0.1.2:
+    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
 
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
@@ -1750,6 +2299,31 @@ packages:
 
   jose@6.1.3:
     resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  jsdom@24.1.3:
+    resolution: {integrity: sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^2.11.2
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   kysely@0.28.8:
     resolution: {integrity: sha512-QUOgl5ZrS9IRuhq5FvOKFSsD/3+IA6MLE81/bOOTRA/YQpKDza2sFdN5g6JCB9BOpqMJDGefLCQ9F12hRS13TA==}
@@ -1825,13 +2399,42 @@ packages:
     resolution: {integrity: sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==}
     engines: {node: '>= 12.0.0'}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
   lucide-react@0.559.0:
     resolution: {integrity: sha512-3ymrkBPXWk3U2bwUDg6TdA6hP5iGDMgPEAMLhchEgTQmA+g0Zk24tOtKtXMx35w1PizTmsBC3RhP88QYm+7mHQ==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.1:
+    resolution: {integrity: sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
 
   motion-dom@12.23.23:
     resolution: {integrity: sha512-n5yolOs0TQQBRUFImrRfs/+6X4p3Q4n1dUEqt/H58Vx7OW6RF+foWEgmTVDhIWJIMXOuNNL0apKH2S16en9eiA==}
@@ -1896,6 +2499,21 @@ packages:
       sass:
         optional: true
 
+  node-releases@2.0.27:
+    resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
+
+  nwsapi@2.2.23:
+    resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   pg-cloudflare@1.2.7:
     resolution: {integrity: sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==}
 
@@ -1933,6 +2551,10 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -1957,6 +2579,20 @@ packages:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  psl@1.15.0:
+    resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  querystringify@2.2.0:
+    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
+
   react-day-picker@9.12.0:
     resolution: {integrity: sha512-t8OvG/Zrciso5CQJu5b1A7yzEmebvST+S3pOVQJWxwjjVngyG/CA2htN/D15dLI4uTEuLLkbZyS4YYt480FAtA==}
     engines: {node: '>=18'}
@@ -1973,6 +2609,13 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-refresh@0.18.0:
+    resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
+    engines: {node: '>=0.10.0'}
 
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
@@ -2008,17 +2651,42 @@ packages:
     resolution: {integrity: sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==}
     engines: {node: '>=0.10.0'}
 
+  requires-port@1.0.0:
+    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+
   reselect@5.1.1:
     resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  rollup@4.54.0:
+    resolution: {integrity: sha512-3nk8Y3a9Ea8szgKhinMlGMhGMw89mqule3KWczxhIzqudyHdCIOHw8WJlj/r329fACjKLEh13ZSk7oE22kyeIw==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   rou3@0.7.11:
     resolution: {integrity: sha512-ELguG3ENDw5NKNmWHO3OGEjcgdxkCNvnMR22gKHEgRXuwiriap5RIYdummOaOiqUNcC5yU5txGCHWNm7KlHuAA==}
 
+  rrweb-cssom@0.7.1:
+    resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
 
   semver@7.7.3:
     resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
@@ -2031,6 +2699,9 @@ packages:
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
   sonner@2.0.7:
     resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
@@ -2053,6 +2724,12 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
@@ -2066,6 +2743,13 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tabbable@6.3.0:
     resolution: {integrity: sha512-EIHvdY5bPLuWForiR/AN2Bxngzpuwn1is4asboytXtpTgsArc+WmSJKVLlhdh71u7jFcryDqB2A8lQvj78MkyQ==}
 
@@ -2078,6 +2762,39 @@ packages:
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.0.2:
+    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.0.3:
+    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
+    engines: {node: '>=14.0.0'}
+
+  tough-cookie@4.1.4:
+    resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
+    engines: {node: '>=6'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
+
+  tsconfck@3.1.6:
+    resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -2097,6 +2814,19 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  universalify@0.2.0:
+    resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
+    engines: {node: '>= 4.0.0'}
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  url-parse@1.5.10:
+    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
@@ -2123,9 +2853,138 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  vite-tsconfig-paths@6.0.3:
+    resolution: {integrity: sha512-7bL7FPX/DSviaZGYUKowWF1AiDVWjMjxNbE8lyaVGDezkedWqfGhlnQ4BZXre0ZN5P4kAgIJfAlgFDVyjrCIyg==}
+    peerDependencies:
+      vite: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
+
+  vite@7.3.0:
+    resolution: {integrity: sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.0.16:
+    resolution: {integrity: sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.0.16
+      '@vitest/browser-preview': 4.0.16
+      '@vitest/browser-webdriverio': 4.0.16
+      '@vitest/ui': 4.0.16
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
   zod@4.1.13:
     resolution: {integrity: sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==}
@@ -2152,7 +3011,127 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
+
+  '@babel/code-frame@7.27.1':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.28.5': {}
+
+  '@babel/core@7.28.5':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/generator': 7.28.5
+      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
+      '@babel/helpers': 7.28.4
+      '@babel/parser': 7.28.5
+      '@babel/template': 7.27.2
+      '@babel/traverse': 7.28.5
+      '@babel/types': 7.28.5
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.28.5':
+    dependencies:
+      '@babel/parser': 7.28.5
+      '@babel/types': 7.28.5
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.27.2':
+    dependencies:
+      '@babel/compat-data': 7.28.5
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.28.1
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-module-imports@7.27.1':
+    dependencies:
+      '@babel/traverse': 7.28.5
+      '@babel/types': 7.28.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.28.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.27.1': {}
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.28.4':
+    dependencies:
+      '@babel/template': 7.27.2
+      '@babel/types': 7.28.5
+
+  '@babel/parser@7.28.5':
+    dependencies:
+      '@babel/types': 7.28.5
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/runtime@7.28.4': {}
+
+  '@babel/template@7.27.2':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/parser': 7.28.5
+      '@babel/types': 7.28.5
+
+  '@babel/traverse@7.28.5':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/generator': 7.28.5
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.28.5
+      '@babel/template': 7.27.2
+      '@babel/types': 7.28.5
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.28.5':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
 
   '@base-ui-components/react@1.0.0-rc.0(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
@@ -2178,6 +3157,8 @@ snapshots:
       use-sync-external-store: 1.6.0(react@19.2.1)
     optionalDependencies:
       '@types/react': 19.2.7
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@better-auth/core@1.4.6(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.18)(better-call@1.1.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.8)(nanostores@1.1.0)':
     dependencies:
@@ -2234,6 +3215,26 @@ snapshots:
 
   '@biomejs/cli-win32-x64@2.2.0':
     optional: true
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@date-fns/tz@1.4.1': {}
 
@@ -3084,6 +4085,74 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@rolldown/pluginutils@1.0.0-beta.53': {}
+
+  '@rollup/rollup-android-arm-eabi@4.54.0':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.54.0':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.54.0':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.54.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.54.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.54.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.54.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.54.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.54.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.54.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.54.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.54.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.54.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.54.0':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.54.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.54.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.54.0':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.54.0':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.54.0':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.54.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.54.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.54.0':
+    optional: true
+
   '@standard-schema/spec@1.0.0': {}
 
   '@standard-schema/utils@0.3.0': {}
@@ -3161,6 +4230,63 @@ snapshots:
       postcss: 8.5.6
       tailwindcss: 4.1.17
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/runtime': 7.28.4
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.1(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@testing-library/dom': 10.4.1
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
+  '@types/aria-query@5.0.4': {}
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.28.5
+      '@babel/types': 7.28.5
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.28.5
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.28.5
+      '@babel/types': 7.28.5
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.28.5
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
+
   '@types/node@20.19.26':
     dependencies:
       undici-types: 6.21.0
@@ -3179,11 +4305,101 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@vitejs/plugin-react@5.1.2(vite@7.3.0(@types/node@20.19.26)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.5)
+      '@rolldown/pluginutils': 1.0.0-beta.53
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.18.0
+      vite: 7.3.0(@types/node@20.19.26)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/coverage-v8@4.0.16(vitest@4.0.16(@types/node@20.19.26)(jiti@2.6.1)(jsdom@24.1.3)(lightningcss@1.30.2)(tsx@4.21.0))':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.0.16
+      ast-v8-to-istanbul: 0.3.9
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magicast: 0.5.1
+      obug: 2.1.1
+      std-env: 3.10.0
+      tinyrainbow: 3.0.3
+      vitest: 4.0.16(@types/node@20.19.26)(jiti@2.6.1)(jsdom@24.1.3)(lightningcss@1.30.2)(tsx@4.21.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/expect@4.0.16':
+    dependencies:
+      '@standard-schema/spec': 1.0.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.0.16
+      '@vitest/utils': 4.0.16
+      chai: 6.2.2
+      tinyrainbow: 3.0.3
+
+  '@vitest/mocker@4.0.16(vite@7.3.0(@types/node@20.19.26)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 4.0.16
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.0(@types/node@20.19.26)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+
+  '@vitest/pretty-format@4.0.16':
+    dependencies:
+      tinyrainbow: 3.0.3
+
+  '@vitest/runner@4.0.16':
+    dependencies:
+      '@vitest/utils': 4.0.16
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.0.16':
+    dependencies:
+      '@vitest/pretty-format': 4.0.16
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.0.16': {}
+
+  '@vitest/utils@4.0.16':
+    dependencies:
+      '@vitest/pretty-format': 4.0.16
+      tinyrainbow: 3.0.3
+
+  agent-base@7.1.4: {}
+
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@5.2.0: {}
+
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
 
-  better-auth@1.4.6(next@16.0.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@0.3.9:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 9.0.1
+
+  asynckit@0.4.0: {}
+
+  baseline-browser-mapping@2.9.11: {}
+
+  better-auth@1.4.6(next@16.0.8(@babel/core@7.28.5)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:
       '@better-auth/core': 1.4.6(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.18)(better-call@1.1.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.8)(nanostores@1.1.0)
       '@better-auth/telemetry': 1.4.6(@better-auth/core@1.4.6(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.18)(better-call@1.1.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.8)(nanostores@1.1.0))
@@ -3199,7 +4415,7 @@ snapshots:
       nanostores: 1.1.0
       zod: 4.1.13
     optionalDependencies:
-      next: 16.0.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      next: 16.0.8(@babel/core@7.28.5)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
 
@@ -3212,9 +4428,24 @@ snapshots:
     optionalDependencies:
       zod: 4.1.13
 
+  browserslist@4.28.1:
+    dependencies:
+      baseline-browser-mapping: 2.9.11
+      caniuse-lite: 1.0.30001760
+      electron-to-chromium: 1.5.267
+      node-releases: 2.0.27
+      update-browserslist-db: 1.2.3(browserslist@4.28.1)
+
   buffer-from@1.1.2: {}
 
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
   caniuse-lite@1.0.30001760: {}
+
+  chai@6.2.2: {}
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -3224,7 +4455,23 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
+  convert-source-map@2.0.0: {}
+
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+
   csstype@3.2.3: {}
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
 
   date-fns-jalali@4.1.0-0: {}
 
@@ -3234,11 +4481,19 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decimal.js@10.6.0: {}
+
   defu@6.1.4: {}
+
+  delayed-stream@1.0.0: {}
+
+  dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
+
+  dom-accessibility-api@0.5.16: {}
 
   dotenv@17.2.3: {}
 
@@ -3257,10 +4512,37 @@ snapshots:
       kysely: 0.28.8
       pg: 8.16.3
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  electron-to-chromium@1.5.267: {}
+
   enhanced-resolve@5.18.3:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.0
+
+  entities@6.0.1: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-module-lexer@1.7.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
 
   esbuild-register@3.6.0(esbuild@0.25.12):
     dependencies:
@@ -3352,6 +4634,26 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.1
       '@esbuild/win32-x64': 0.27.1
 
+  escalade@3.2.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+
   framer-motion@12.23.26(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:
       motion-dom: 12.23.23
@@ -3364,17 +4666,138 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
+  gensync@1.0.0-beta.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
   get-nonce@1.0.1: {}
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
 
   get-tsconfig@4.13.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  globrex@0.1.2: {}
+
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
+
+  has-flag@4.0.0: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
+  html-escaper@2.0.2: {}
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  is-potential-custom-element-name@1.0.1: {}
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
 
   jiti@2.6.1: {}
 
   jose@6.1.3: {}
+
+  js-tokens@4.0.0: {}
+
+  js-tokens@9.0.1: {}
+
+  jsdom@24.1.3:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      form-data: 4.0.5
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.23
+      parse5: 7.3.0
+      rrweb-cssom: 0.7.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 4.1.4
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.18.3
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  jsesc@3.1.0: {}
+
+  json5@2.2.3: {}
 
   kysely@0.28.8: {}
 
@@ -3427,13 +4850,39 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.30.2
       lightningcss-win32-x64-msvc: 1.30.2
 
+  lru-cache@10.4.3: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
   lucide-react@0.559.0(react@19.2.1):
     dependencies:
       react: 19.2.1
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.1:
+    dependencies:
+      '@babel/parser': 7.28.5
+      '@babel/types': 7.28.5
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.3
+
+  math-intrinsics@1.1.0: {}
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   motion-dom@12.23.23:
     dependencies:
@@ -3462,7 +4911,7 @@ snapshots:
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
 
-  next@16.0.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
+  next@16.0.8(@babel/core@7.28.5)(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:
       '@next/env': 16.0.8
       '@swc/helpers': 0.5.15
@@ -3470,7 +4919,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
-      styled-jsx: 5.1.6(react@19.2.1)
+      styled-jsx: 5.1.6(@babel/core@7.28.5)(react@19.2.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.0.8
       '@next/swc-darwin-x64': 16.0.8
@@ -3484,6 +4933,18 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+
+  node-releases@2.0.27: {}
+
+  nwsapi@2.2.23: {}
+
+  obug@2.1.1: {}
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
+  pathe@2.0.3: {}
 
   pg-cloudflare@1.2.7:
     optional: true
@@ -3522,6 +4983,8 @@ snapshots:
 
   picocolors@1.1.1: {}
 
+  picomatch@4.0.3: {}
+
   postcss@8.4.31:
     dependencies:
       nanoid: 3.3.11
@@ -3544,6 +5007,20 @@ snapshots:
     dependencies:
       xtend: 4.0.2
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
+  psl@1.15.0:
+    dependencies:
+      punycode: 2.3.1
+
+  punycode@2.3.1: {}
+
+  querystringify@2.2.0: {}
+
   react-day-picker@9.12.0(react@19.2.1):
     dependencies:
       '@date-fns/tz': 1.4.1
@@ -3559,6 +5036,10 @@ snapshots:
   react-hook-form@7.68.0(react@19.2.1):
     dependencies:
       react: 19.2.1
+
+  react-is@17.0.2: {}
+
+  react-refresh@0.18.0: {}
 
   react-remove-scroll-bar@2.3.8(@types/react@19.2.7)(react@19.2.1):
     dependencies:
@@ -3589,16 +5070,57 @@ snapshots:
 
   react@19.2.1: {}
 
+  requires-port@1.0.0: {}
+
   reselect@5.1.1: {}
 
   resolve-pkg-maps@1.0.0: {}
 
+  rollup@4.54.0:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.54.0
+      '@rollup/rollup-android-arm64': 4.54.0
+      '@rollup/rollup-darwin-arm64': 4.54.0
+      '@rollup/rollup-darwin-x64': 4.54.0
+      '@rollup/rollup-freebsd-arm64': 4.54.0
+      '@rollup/rollup-freebsd-x64': 4.54.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.54.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.54.0
+      '@rollup/rollup-linux-arm64-gnu': 4.54.0
+      '@rollup/rollup-linux-arm64-musl': 4.54.0
+      '@rollup/rollup-linux-loong64-gnu': 4.54.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.54.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.54.0
+      '@rollup/rollup-linux-riscv64-musl': 4.54.0
+      '@rollup/rollup-linux-s390x-gnu': 4.54.0
+      '@rollup/rollup-linux-x64-gnu': 4.54.0
+      '@rollup/rollup-linux-x64-musl': 4.54.0
+      '@rollup/rollup-openharmony-arm64': 4.54.0
+      '@rollup/rollup-win32-arm64-msvc': 4.54.0
+      '@rollup/rollup-win32-ia32-msvc': 4.54.0
+      '@rollup/rollup-win32-x64-gnu': 4.54.0
+      '@rollup/rollup-win32-x64-msvc': 4.54.0
+      fsevents: 2.3.3
+
   rou3@0.7.11: {}
+
+  rrweb-cssom@0.7.1: {}
+
+  rrweb-cssom@0.8.0: {}
+
+  safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
-  semver@7.7.3:
-    optional: true
+  semver@6.3.1: {}
+
+  semver@7.7.3: {}
 
   set-cookie-parser@2.7.2: {}
 
@@ -3634,6 +5156,8 @@ snapshots:
       '@img/sharp-win32-x64': 0.34.5
     optional: true
 
+  siginfo@2.0.0: {}
+
   sonner@2.0.7(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:
       react: 19.2.1
@@ -3650,10 +5174,22 @@ snapshots:
 
   split2@4.2.0: {}
 
-  styled-jsx@5.1.6(react@19.2.1):
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  styled-jsx@5.1.6(@babel/core@7.28.5)(react@19.2.1):
     dependencies:
       client-only: 0.0.1
       react: 19.2.1
+    optionalDependencies:
+      '@babel/core': 7.28.5
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  symbol-tree@3.2.4: {}
 
   tabbable@6.3.0: {}
 
@@ -3662,6 +5198,32 @@ snapshots:
   tailwindcss@4.1.17: {}
 
   tapable@2.3.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.0.2: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  tinyrainbow@3.0.3: {}
+
+  tough-cookie@4.1.4:
+    dependencies:
+      psl: 1.15.0
+      punycode: 2.3.1
+      universalify: 0.2.0
+      url-parse: 1.5.10
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
+
+  tsconfck@3.1.6(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
 
   tslib@2.8.1: {}
 
@@ -3677,6 +5239,19 @@ snapshots:
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
+
+  universalify@0.2.0: {}
+
+  update-browserslist-db@1.2.3(browserslist@4.28.1):
+    dependencies:
+      browserslist: 4.28.1
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  url-parse@1.5.10:
+    dependencies:
+      querystringify: 2.2.0
+      requires-port: 1.0.0
 
   use-callback-ref@1.3.3(@types/react@19.2.7)(react@19.2.1):
     dependencies:
@@ -3697,7 +5272,101 @@ snapshots:
     dependencies:
       react: 19.2.1
 
+  vite-tsconfig-paths@6.0.3(typescript@5.9.3)(vite@7.3.0(@types/node@20.19.26)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)):
+    dependencies:
+      debug: 4.4.3
+      globrex: 0.1.2
+      tsconfck: 3.1.6(typescript@5.9.3)
+    optionalDependencies:
+      vite: 7.3.0(@types/node@20.19.26)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  vite@7.3.0(@types/node@20.19.26)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0):
+    dependencies:
+      esbuild: 0.27.1
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.54.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 20.19.26
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.30.2
+      tsx: 4.21.0
+
+  vitest@4.0.16(@types/node@20.19.26)(jiti@2.6.1)(jsdom@24.1.3)(lightningcss@1.30.2)(tsx@4.21.0):
+    dependencies:
+      '@vitest/expect': 4.0.16
+      '@vitest/mocker': 4.0.16(vite@7.3.0(@types/node@20.19.26)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.0.16
+      '@vitest/runner': 4.0.16
+      '@vitest/snapshot': 4.0.16
+      '@vitest/spy': 4.0.16
+      '@vitest/utils': 4.0.16
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.3.0(@types/node@20.19.26)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.26
+      jsdom: 24.1.3
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  ws@8.18.3: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
+
   xtend@4.0.2: {}
+
+  yallist@3.1.1: {}
 
   zod@4.1.13: {}
 

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,0 +1,36 @@
+import react from '@vitejs/plugin-react'
+import tsconfigPaths from 'vite-tsconfig-paths'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  plugins: [react(), tsconfigPaths()],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.mts'],
+    include: ['**/__tests__/**/*.test.{ts,tsx}'],
+    exclude: ['node_modules', '.next', 'drizzle'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      exclude: [
+        'node_modules/**',
+        '.next/**',
+        'drizzle/**',
+        '**/*.d.ts',
+        '**/*.config.{ts,js,mjs}',
+        '**/types.ts',
+        'vitest.setup.ts',
+        '__tests__/**',
+      ],
+      thresholds: {
+        global: {
+          statements: 70,
+          branches: 70,
+          functions: 70,
+          lines: 70,
+        },
+      },
+    },
+  },
+})

--- a/vitest.setup.mts
+++ b/vitest.setup.mts
@@ -1,0 +1,26 @@
+import { vi } from 'vitest'
+
+// Mock next/navigation
+vi.mock('next/navigation', () => ({
+  useRouter: vi.fn(() => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+  })),
+  usePathname: vi.fn(() => '/'),
+  useSearchParams: vi.fn(() => new URLSearchParams()),
+  useParams: vi.fn(() => ({})),
+  redirect: vi.fn(),
+  notFound: vi.fn(),
+}))
+
+// Mock next/cache
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+  revalidateTag: vi.fn(),
+  unstable_cache: vi.fn((fn) => fn),
+  unstable_noStore: vi.fn(),
+}))


### PR DESCRIPTION
- Set up Vitest with ESM and JSDom support
- Add mocks for Drizzle ORM and authentication
- Add unit tests for:
  - Server Actions (Board, List, Card, Label)
  - Zod Schemas (Auth, Board, List, Card, Label)
  - UI Components (Button, Input)
  - Zustand Store and Utilities
- Achieve ~70% overall code coverage