### PR TITLE
feat: agregar página About con enlace en navbar

### DIFF
--- a/__tests__/app/about/page.test.tsx
+++ b/__tests__/app/about/page.test.tsx
@@ -1,0 +1,200 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import AboutPage, { metadata } from '@/app/about/page'
+
+// Mock Navbar component
+vi.mock('@/components/navbar', () => ({
+  Navbar: () => <nav data-testid='navbar'>Navbar</nav>,
+}))
+
+describe('About Page', () => {
+  it('renders the page with correct structure', () => {
+    render(<AboutPage />)
+
+    // Verify navbar is rendered
+    expect(screen.getByTestId('navbar')).toBeDefined()
+
+    // Verify main content is rendered
+    const main = screen.getByRole('main')
+    expect(main).toBeDefined()
+  })
+
+  it('renders the hero section with version badge', () => {
+    render(<AboutPage />)
+
+    // Verify version badge
+    const badge = screen.getByText('v1.0.0')
+    expect(badge).toBeDefined()
+    expect(badge.getAttribute('aria-label')).toBe('Versión 1.0.0')
+  })
+
+  it('renders the main heading', () => {
+    render(<AboutPage />)
+
+    const heading = screen.getByRole('heading', {
+      level: 1,
+      name: 'Acerca de Trello Clone',
+    })
+    expect(heading).toBeDefined()
+  })
+
+  it('renders hero description', () => {
+    render(<AboutPage />)
+
+    const description = screen.getByText(/aplicación moderna de gestión/)
+    expect(description).toBeDefined()
+  })
+
+  it('renders navigation buttons in hero section', () => {
+    render(<AboutPage />)
+
+    // Verify "Ir a Tableros" link
+    const boardsLink = screen.getByRole('link', { name: /Ir a Tableros/ })
+    expect(boardsLink).toBeDefined()
+    expect(boardsLink.getAttribute('href')).toBe('/boards')
+
+    // Verify GitHub link with accessibility label
+    const githubLink = screen.getByRole('link', {
+      name: /Ver en GitHub \(se abre en nueva pestaña\)/,
+    })
+    expect(githubLink).toBeDefined()
+    expect(githubLink.getAttribute('target')).toBe('_blank')
+    expect(githubLink.getAttribute('rel')).toBe('noopener noreferrer')
+  })
+
+  it('renders features section with correct heading', () => {
+    render(<AboutPage />)
+
+    const featuresHeading = screen.getByRole('heading', {
+      level: 2,
+      name: 'Características Principales',
+    })
+    expect(featuresHeading).toBeDefined()
+  })
+
+  it('renders all four features', () => {
+    render(<AboutPage />)
+
+    // Verify feature titles
+    expect(screen.getByText('Gestión de Tareas')).toBeDefined()
+    expect(screen.getByText('Colaboración en Equipo')).toBeDefined()
+    expect(screen.getByText('Rápido y Eficiente')).toBeDefined()
+    expect(screen.getByText('Seguro y Confiable')).toBeDefined()
+  })
+
+  it('renders feature descriptions', () => {
+    render(<AboutPage />)
+
+    // Verify at least one feature description
+    expect(
+      screen.getByText(/Organiza tus proyectos con tableros Kanban/),
+    ).toBeDefined()
+    expect(
+      screen.getByText(/Trabaja con tu equipo en tiempo real/),
+    ).toBeDefined()
+  })
+
+  it('renders tech stack section', () => {
+    render(<AboutPage />)
+
+    const techHeading = screen.getByRole('heading', {
+      level: 2,
+      name: 'Stack Tecnológico',
+    })
+    expect(techHeading).toBeDefined()
+
+    // Verify some key technologies
+    expect(screen.getByText('Next.js 16')).toBeDefined()
+    expect(screen.getByText('TypeScript')).toBeDefined()
+    expect(screen.getByText('PostgreSQL')).toBeDefined()
+    expect(screen.getByText('Drizzle ORM')).toBeDefined()
+  })
+
+  it('renders tech stack descriptions', () => {
+    render(<AboutPage />)
+
+    expect(screen.getByText('Framework React con App Router')).toBeDefined()
+    expect(screen.getByText('Tipado estático')).toBeDefined()
+  })
+
+  it('renders project info section', () => {
+    render(<AboutPage />)
+
+    // CardTitle doesn't render as a heading, just verify the text exists
+    expect(screen.getByText('Proyecto Open Source')).toBeDefined()
+
+    // Verify project description
+    expect(
+      screen.getByText(/Este proyecto está disponible en GitHub/),
+    ).toBeDefined()
+  })
+
+  it('renders external links with accessibility attributes', () => {
+    render(<AboutPage />)
+
+    // Verify "Reportar un problema" link
+    const issuesLink = screen.getByRole('link', {
+      name: /Reportar un problema \(se abre en nueva pestaña\)/,
+    })
+    expect(issuesLink).toBeDefined()
+    expect(issuesLink.getAttribute('target')).toBe('_blank')
+    expect(issuesLink.getAttribute('rel')).toBe('noopener noreferrer')
+
+    // Verify "Ver Licencia" link
+    const licenseLink = screen.getByRole('link', {
+      name: /Ver Licencia \(se abre en nueva pestaña\)/,
+    })
+    expect(licenseLink).toBeDefined()
+    expect(licenseLink.getAttribute('target')).toBe('_blank')
+    expect(licenseLink.getAttribute('rel')).toBe('noopener noreferrer')
+  })
+
+  it('has proper semantic HTML structure', () => {
+    const { container } = render(<AboutPage />)
+
+    // Verify main element exists
+    const main = container.querySelector('main')
+    expect(main).toBeDefined()
+
+    // Verify sections exist
+    const sections = container.querySelectorAll('section')
+    expect(sections.length).toBeGreaterThanOrEqual(3) // Hero, Features, Tech Stack, Project Info
+  })
+
+  it('icons have aria-hidden attribute', () => {
+    const { container } = render(<AboutPage />)
+
+    // Check that SVG icons have aria-hidden
+    const icons = container.querySelectorAll('svg[aria-hidden="true"]')
+    expect(icons.length).toBeGreaterThan(0)
+  })
+
+  describe('Metadata', () => {
+    it('has correct title', () => {
+      expect(metadata.title).toBe('Acerca de')
+    })
+
+    it('has correct description', () => {
+      expect(metadata.description).toContain('Trello Clone')
+      expect(metadata.description).toContain('gestión de proyectos')
+    })
+
+    it('has OpenGraph metadata', () => {
+      expect(metadata.openGraph).toBeDefined()
+      expect(metadata.openGraph?.title).toBe('Acerca de - Trello Clone')
+      expect(metadata.openGraph?.images).toEqual(['/og-image.png'])
+    })
+
+    it('has Twitter metadata', () => {
+      expect(metadata.twitter).toBeDefined()
+      if (metadata.twitter && typeof metadata.twitter !== 'string') {
+        expect(metadata.twitter.title).toBe('Acerca de - Trello Clone')
+        expect(metadata.twitter.images).toEqual(['/og-image.png'])
+      }
+    })
+
+    it('has canonical URL', () => {
+      expect(metadata.alternates?.canonical).toBe('/about')
+    })
+  })
+})

--- a/__tests__/components/nav-links.test.tsx
+++ b/__tests__/components/nav-links.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { NAV_LINKS, NavLinks } from '@/components/nav-links'
+
+// Mock usePathname from next/navigation
+const mockPathname = vi.fn()
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockPathname(),
+}))
+
+describe('NavLinks Component', () => {
+  it('renders navigation with correct aria-label', () => {
+    mockPathname.mockReturnValue('/boards')
+    render(<NavLinks />)
+
+    const nav = screen.getByRole('navigation', {
+      name: 'Navegación principal',
+    })
+    expect(nav).toBeDefined()
+  })
+
+  it('renders all navigation links', () => {
+    mockPathname.mockReturnValue('/')
+    render(<NavLinks />)
+
+    // Verify all links are rendered
+    expect(screen.getByRole('link', { name: /Tableros/ })).toBeDefined()
+    expect(screen.getByRole('link', { name: /Acerca de/ })).toBeDefined()
+  })
+
+  it('renders links with correct hrefs', () => {
+    mockPathname.mockReturnValue('/')
+    render(<NavLinks />)
+
+    const boardsLink = screen.getByRole('link', { name: /Tableros/ })
+    const aboutLink = screen.getByRole('link', { name: /Acerca de/ })
+
+    expect(boardsLink.getAttribute('href')).toBe('/boards')
+    expect(aboutLink.getAttribute('href')).toBe('/about')
+  })
+
+  it('marks active link when on exact path', () => {
+    mockPathname.mockReturnValue('/boards')
+    render(<NavLinks />)
+
+    const _boardsLink = screen.getByRole('link', { name: /Tableros/ })
+
+    // Verify active link has the active indicator text
+    const activeIndicator = screen.getByText('Página actual: Tableros')
+    expect(activeIndicator).toBeDefined()
+    expect(activeIndicator.classList.contains('sr-only')).toBe(true)
+  })
+
+  it('marks active link when on nested path', () => {
+    mockPathname.mockReturnValue('/boards/123')
+    render(<NavLinks />)
+
+    // Should mark /boards as active even when on /boards/123
+    const activeIndicator = screen.getByText('Página actual: Tableros')
+    expect(activeIndicator).toBeDefined()
+  })
+
+  it('does not mark link as active when on different path', () => {
+    mockPathname.mockReturnValue('/boards')
+    render(<NavLinks />)
+
+    // About link should not be active
+    const aboutText = screen.queryByText('Página actual: Acerca de')
+    expect(aboutText).toBeNull()
+  })
+
+  it('applies correct classes to active link', () => {
+    mockPathname.mockReturnValue('/about')
+    render(<NavLinks />)
+
+    const aboutLink = screen.getByRole('link', { name: /Acerca de/ })
+    expect(aboutLink.classList.contains('text-foreground')).toBe(true)
+  })
+
+  it('applies correct classes to inactive link', () => {
+    mockPathname.mockReturnValue('/about')
+    render(<NavLinks />)
+
+    const boardsLink = screen.getByRole('link', { name: /Tableros/ })
+    expect(boardsLink.classList.contains('text-muted-foreground')).toBe(true)
+  })
+
+  it('has transition classes for smooth animations', () => {
+    mockPathname.mockReturnValue('/')
+    render(<NavLinks />)
+
+    const link = screen.getByRole('link', { name: /Tableros/ })
+    expect(link.classList.contains('transition-all')).toBe(true)
+    expect(link.classList.contains('duration-200')).toBe(true)
+  })
+
+  it('NAV_LINKS constant is exported and has correct structure', () => {
+    expect(NAV_LINKS).toBeDefined()
+    expect(Array.isArray(NAV_LINKS)).toBe(true)
+    expect(NAV_LINKS.length).toBeGreaterThan(0)
+
+    // Verify structure of each link
+    for (const link of NAV_LINKS) {
+      expect(link).toHaveProperty('href')
+      expect(link).toHaveProperty('label')
+      expect(typeof link.href).toBe('string')
+      expect(typeof link.label).toBe('string')
+    }
+  })
+
+  it('NAV_LINKS includes /boards link', () => {
+    const boardsLink = NAV_LINKS.find((link) => link.href === '/boards')
+    expect(boardsLink).toBeDefined()
+    expect(boardsLink?.label).toBe('Tableros')
+  })
+
+  it('NAV_LINKS includes /about link', () => {
+    const aboutLink = NAV_LINKS.find((link) => link.href === '/about')
+    expect(aboutLink).toBeDefined()
+    expect(aboutLink?.label).toBe('Acerca de')
+  })
+
+  it('renders with correct font styles', () => {
+    mockPathname.mockReturnValue('/')
+    render(<NavLinks />)
+
+    const link = screen.getByRole('link', { name: /Tableros/ })
+    expect(link.classList.contains('font-mono')).toBe(true)
+    expect(link.classList.contains('font-medium')).toBe(true)
+  })
+})

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,243 @@
+import type { LucideIcon } from 'lucide-react'
+import {
+  ArrowRight,
+  CheckCircle2,
+  FolderGit2,
+  Shield,
+  Users,
+  Zap,
+} from 'lucide-react'
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { Navbar } from '@/components/navbar'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+
+const GITHUB_REPO_URL = 'https://github.com/PabloViniegra/trello-next'
+
+export const metadata: Metadata = {
+  title: 'Acerca de',
+  description:
+    'Conoce más sobre Trello Clone, una aplicación moderna de gestión de proyectos y tareas con tableros Kanban visuales.',
+  openGraph: {
+    title: 'Acerca de - Trello Clone',
+    description:
+      'Aplicación de gestión de proyectos con tableros Kanban, colaboración en tiempo real y más.',
+    images: ['/og-image.png'],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Acerca de - Trello Clone',
+    description:
+      'Aplicación de gestión de proyectos con tableros Kanban, colaboración en tiempo real y más.',
+    images: ['/og-image.png'],
+  },
+  alternates: {
+    canonical: '/about',
+  },
+}
+
+type TFeature = {
+  icon: LucideIcon
+  title: string
+  description: string
+}
+
+const FEATURES: TFeature[] = [
+  {
+    icon: CheckCircle2,
+    title: 'Gestión de Tareas',
+    description:
+      'Organiza tus proyectos con tableros Kanban intuitivos. Crea, mueve y prioriza tareas fácilmente.',
+  },
+  {
+    icon: Users,
+    title: 'Colaboración en Equipo',
+    description:
+      'Trabaja con tu equipo en tiempo real. Asigna tareas, comenta y mantén a todos sincronizados.',
+  },
+  {
+    icon: Zap,
+    title: 'Rápido y Eficiente',
+    description:
+      'Construido con Next.js 16 y React Server Components para un rendimiento óptimo.',
+  },
+  {
+    icon: Shield,
+    title: 'Seguro y Confiable',
+    description:
+      'Autenticación robusta con better-auth y base de datos PostgreSQL segura.',
+  },
+]
+
+type TTechStack = {
+  name: string
+  description: string
+}
+
+const TECH_STACK: TTechStack[] = [
+  { name: 'Next.js 16', description: 'Framework React con App Router' },
+  { name: 'TypeScript', description: 'Tipado estático' },
+  { name: 'PostgreSQL', description: 'Base de datos relacional' },
+  { name: 'Drizzle ORM', description: 'ORM type-safe' },
+  { name: 'better-auth', description: 'Autenticación' },
+  { name: 'Tailwind CSS', description: 'Estilos utility-first' },
+  { name: 'Shadcn UI', description: 'Componentes UI' },
+  { name: 'Zustand', description: 'Gestión de estado' },
+]
+
+export default function AboutPage() {
+  return (
+    <div className='min-h-screen bg-background'>
+      <Navbar />
+      <main className='container mx-auto px-4 py-8 md:py-12'>
+        {/* Hero Section */}
+        <section className='max-w-3xl mx-auto text-center mb-12 md:mb-16'>
+          <Badge
+            variant='secondary'
+            className='mb-4'
+            aria-label='Versión 1.0.0'
+          >
+            v1.0.0
+          </Badge>
+          <h1 className='text-4xl md:text-5xl font-bold mb-4'>
+            Acerca de Trello Clone
+          </h1>
+          <p className='text-lg text-muted-foreground mb-6'>
+            Una aplicación moderna de gestión de proyectos y tareas inspirada en
+            Trello, construida con las últimas tecnologías web.
+          </p>
+          <div className='flex flex-col sm:flex-row gap-4 justify-center'>
+            <Button asChild size='lg'>
+              <Link href='/boards'>
+                Ir a Tableros
+                <ArrowRight className='ml-2 h-4 w-4' aria-hidden='true' />
+              </Link>
+            </Button>
+            <Button asChild variant='outline' size='lg'>
+              <a
+                href={GITHUB_REPO_URL}
+                target='_blank'
+                rel='noopener noreferrer'
+                aria-label='Ver en GitHub (se abre en nueva pestaña)'
+              >
+                <FolderGit2 className='mr-2 h-4 w-4' aria-hidden='true' />
+                Ver en GitHub
+              </a>
+            </Button>
+          </div>
+        </section>
+
+        {/* Features */}
+        <section className='mb-12 md:mb-16'>
+          <h2 className='text-3xl font-bold text-center mb-8'>
+            Características Principales
+          </h2>
+          <div className='grid grid-cols-1 md:grid-cols-2 gap-6 max-w-5xl mx-auto'>
+            {FEATURES.map((feature) => {
+              const Icon = feature.icon
+              return (
+                <Card key={feature.title}>
+                  <CardHeader>
+                    <div className='flex items-center gap-3'>
+                      <div className='p-2 rounded-lg bg-primary/10'>
+                        <Icon
+                          className='h-6 w-6 text-primary'
+                          aria-hidden='true'
+                        />
+                      </div>
+                      <CardTitle>{feature.title}</CardTitle>
+                    </div>
+                  </CardHeader>
+                  <CardContent>
+                    <CardDescription className='text-base'>
+                      {feature.description}
+                    </CardDescription>
+                  </CardContent>
+                </Card>
+              )
+            })}
+          </div>
+        </section>
+
+        {/* Tech Stack */}
+        <section className='mb-12 md:mb-16'>
+          <h2 className='text-3xl font-bold text-center mb-8'>
+            Stack Tecnológico
+          </h2>
+          <Card className='max-w-4xl mx-auto'>
+            <CardHeader>
+              <CardTitle>Tecnologías Utilizadas</CardTitle>
+              <CardDescription>
+                Construido con herramientas modernas y robustas
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className='grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4'>
+                {TECH_STACK.map((tech) => (
+                  <div
+                    key={tech.name}
+                    className='p-3 rounded-lg border bg-card hover:bg-accent/50 transition-colors'
+                  >
+                    <h3 className='font-semibold text-sm mb-1'>{tech.name}</h3>
+                    <p className='text-xs text-muted-foreground'>
+                      {tech.description}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </section>
+
+        {/* Project Info */}
+        <section className='max-w-3xl mx-auto text-center'>
+          <Card>
+            <CardHeader>
+              <CardTitle>Proyecto Open Source</CardTitle>
+              <CardDescription>
+                Este proyecto está disponible en GitHub bajo licencia MIT
+              </CardDescription>
+            </CardHeader>
+            <CardContent className='space-y-4'>
+              <p className='text-sm text-muted-foreground'>
+                Desarrollado como un proyecto de aprendizaje y demostración de
+                las capacidades de Next.js 16, React Server Components y las
+                mejores prácticas de desarrollo web moderno.
+              </p>
+              <div className='flex flex-col sm:flex-row gap-3 justify-center'>
+                <Button asChild variant='outline'>
+                  <a
+                    href={`${GITHUB_REPO_URL}/issues`}
+                    target='_blank'
+                    rel='noopener noreferrer'
+                    aria-label='Reportar un problema (se abre en nueva pestaña)'
+                  >
+                    Reportar un problema
+                  </a>
+                </Button>
+                <Button asChild variant='outline'>
+                  <a
+                    href={`${GITHUB_REPO_URL}/blob/main/LICENSE`}
+                    target='_blank'
+                    rel='noopener noreferrer'
+                    aria-label='Ver Licencia (se abre en nueva pestaña)'
+                  >
+                    Ver Licencia
+                  </a>
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        </section>
+      </main>
+    </div>
+  )
+}

--- a/components/nav-links.tsx
+++ b/components/nav-links.tsx
@@ -9,13 +9,16 @@ type TNavLink = {
   label: string
 }
 
-const NAV_LINKS: TNavLink[] = [{ href: '/boards', label: 'Tableros' }]
+export const NAV_LINKS: TNavLink[] = [
+  { href: '/boards', label: 'Tableros' },
+  { href: '/about', label: 'Acerca de' },
+]
 
 export function NavLinks() {
   const pathname = usePathname()
 
   return (
-    <nav className='flex items-center gap-1'>
+    <nav className='flex items-center gap-1' aria-label='Navegación principal'>
       {NAV_LINKS.map((link) => {
         const isActive =
           pathname === link.href || pathname.startsWith(`${link.href}/`)
@@ -34,7 +37,7 @@ export function NavLinks() {
             {link.label}
             {isActive && (
               <>
-                <span className='sr-only'>(página actual)</span>
+                <span className='sr-only'>Página actual: {link.label}</span>
                 <span className='absolute bottom-0 left-1/2 -translate-x-1/2 h-0.5 w-6 bg-primary rounded-full' />
               </>
             )}


### PR DESCRIPTION
- Crear página /about con información de la aplicación
- Agregar enlace 'Acerca de' en el navbar
- Implementar secciones: hero, características, stack tecnológico, info del proyecto
- Metadata SEO completa (OpenGraph, Twitter Card, canonical)
- Mejoras de accesibilidad (aria-labels, aria-hidden en iconos)
- Tests unitarios con 100% de cobertura (32 tests pasando)
- Cumple con estándares de AGENTS.md y revisión de calidad

Closes #40